### PR TITLE
Fix Subject references and dialog issues

### DIFF
--- a/examgen/models.py
+++ b/examgen/models.py
@@ -61,8 +61,9 @@ class Subject(Base):
     name: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
     description: Mapped[str | None] = mapped_column(Text())
 
-    questions:   Mapped[List["Question"]] = relationship(back_populates="subject",   foreign_keys="Question.subject_id")
-    references_: Mapped[List["Question"]] = relationship(back_populates="reference", foreign_keys="Question.reference_id")
+    questions: Mapped[List["Question"]] = relationship(
+        back_populates="subject", foreign_keys="Question.subject_id"
+    )
 
 
 class Question(Base):


### PR DESCRIPTION
## Summary
- remove obsolete `references_` relation from `Subject`
- drop broken reference combo box from `QuestionDialog`
- preload subjects when dialog opens
- clean up unused variable

## Testing
- `python -m py_compile examgen/gui/dialogs.py examgen/models.py`

------
https://chatgpt.com/codex/tasks/task_e_683c304463d48329a05a6fb6bca692b5