### PR TITLE
Fix completer crash on non-editable combo

### DIFF
--- a/examgen/gui/dialogs.py
+++ b/examgen/gui/dialogs.py
@@ -199,6 +199,7 @@ class ExamConfigDialog(QDialog):
         self.config: Optional[ExamConfig] = None
 
         self.cb_subject = QComboBox()
+        self.cb_subject.setEditable(True)
         self.spin_time = QSpinBox(minimum=1, maximum=999, value=90)
 
         self.spin_questions = QSpinBox(minimum=1, maximum=999, value=60)
@@ -283,9 +284,10 @@ class ExamConfigDialog(QDialog):
 
         self.cb_subject.addItems(names)
 
-        completer = QCompleter(self.cb_subject.model(), self)
-        completer.setCaseSensitivity(Qt.CaseInsensitive)
-        self.cb_subject.setCompleter(completer)
+        if self.cb_subject.isEditable():
+            completer = QCompleter(self.cb_subject.model(), self)
+            completer.setCaseSensitivity(Qt.CaseInsensitive)
+            self.cb_subject.setCompleter(completer)
 
         no_subjects = len(names) == 0
         self.lbl_no_subjects.setVisible(no_subjects)


### PR DESCRIPTION
## Summary
- make subject combo editable in `ExamConfigDialog`
- guard completer creation when combo isn't editable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9e0c7da88329a66702f90eb7c2b9