### PR TITLE
Ensure exam lookup when id missing

### DIFF
--- a/examgen/services/exam_service.py
+++ b/examgen/services/exam_service.py
@@ -14,6 +14,7 @@ from examgen.models import (
     Question,
     ExamQuestion,
     SelectorTypeEnum,
+    Exam,
 )
 
 
@@ -92,6 +93,12 @@ def _select_by_errors(
 def create_attempt(config: ExamConfig) -> Attempt:
     """Persist a new Attempt with its questions."""
     with SessionLocal() as session:
+        if config.exam_id == 0:
+            exam = session.query(Exam).filter_by(subject=config.subject).first()
+            if not exam:
+                raise ValueError(f"No exam with subject {config.subject}")
+            config.exam_id = exam.id
+
         attempt = Attempt(
             exam_id=config.exam_id,
             subject=config.subject,


### PR DESCRIPTION
## Summary
- ensure `create_attempt` resolves exam id by subject when not provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ca6b0fd8c8329843e9df585b1f6dd