### PR TITLE
Correct empty subjects check

### DIFF
--- a/examgen/gui/dialogs.py
+++ b/examgen/gui/dialogs.py
@@ -276,7 +276,7 @@ class ExamConfigDialog(QDialog):
         else:
             self.cb_subject.setCompleter(None)
 
-        no_subjects = len(names) == 0
+        no_subjects = len(subjects) == 0
         self.lbl_no_subjects.setVisible(no_subjects)
         self._update_ok_state()
 


### PR DESCRIPTION
## Summary
- fix NameError in `_load_subjects` in `examgen/gui/dialogs.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d688118248329a79985d4b8c9eb6c