### PR TITLE
Track open exam windows

### DIFF
--- a/examgen/gui/main.py
+++ b/examgen/gui/main.py
@@ -44,6 +44,7 @@ from PySide6.QtWidgets import (
     QMenuBar,
     QStatusBar,
     QMessageBox,
+    QWidget,
 )
 
 from examgen import models as m
@@ -58,6 +59,7 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("ExamGen")
         self.resize(1280, 720)
+        self._open_exams: list[QWidget] = []
 
         # Tema actual
         self.current_theme = THEME
@@ -93,13 +95,16 @@ class MainWindow(QMainWindow):
             cfg = ExamConfigDialog.get_config(window)
             if cfg:
                 try:
-                    start_exam(cfg, parent=window)
+                    win = start_exam(cfg, parent=window)
                 except ValueError:
                     QMessageBox.warning(
                         window,
                         "No hay preguntas",
                         f"No hay preguntas para la materia \"{cfg.subject}\"",
                     )
+                else:
+                    window._open_exams.append(win)
+                    win.destroyed.connect(lambda: window._open_exams.remove(win))
 
         exam_action = QAction("Hacer examen…", self)
         exam_action.setShortcut(QKeySequence("Ctrl+E"))

--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -233,6 +233,8 @@ def start_exam(config: ExamConfig, parent: QWidget | None = None) -> ExamWindow:
     attempt = create_attempt(config)
     win = ExamWindow(attempt, parent)
     win.show()
+    win.raise_()
+    win.activateWindow()
     return win
 
 


### PR DESCRIPTION
## Summary
- keep references to ExamWindow instances to avoid destruction
- focus exam windows when starting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d9310af18832981c6427ede6b40a5