### PR TITLE
Convert ExamWindow into modal ExamDialog

### DIFF
--- a/examgen/gui/__init__.py
+++ b/examgen/gui/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .widgets import ExamWindow, start_exam
+from .widgets import ExamDialog, start_exam
 
-__all__ = ["ExamWindow", "start_exam"]
+__all__ = ["ExamDialog", "start_exam"]

--- a/examgen/gui/main.py
+++ b/examgen/gui/main.py
@@ -59,7 +59,6 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("ExamGen")
         self.resize(1280, 720)
-        self._open_exams: list[QWidget] = []
 
         # Tema actual
         self.current_theme = THEME
@@ -95,16 +94,14 @@ class MainWindow(QMainWindow):
             cfg = ExamConfigDialog.get_config(window)
             if cfg:
                 try:
-                    win = start_exam(cfg, parent=window)
+                    if start_exam(cfg, parent=window):
+                        print("Examen completado")
                 except ValueError:
                     QMessageBox.warning(
                         window,
                         "No hay preguntas",
-                        f"No hay preguntas para la materia \"{cfg.subject}\"",
+                        f'No hay preguntas para la materia "{cfg.subject}"',
                     )
-                else:
-                    window._open_exams.append(win)
-                    win.destroyed.connect(lambda: window._open_exams.remove(win))
 
         exam_action = QAction("Hacer examen…", self)
         exam_action.setShortcut(QKeySequence("Ctrl+E"))

--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -67,11 +67,12 @@ class OptionTable(QTableWidget):
         return opts, correct
 
 
-class ExamWindow(QWidget):
-    """Window showing an ongoing exam attempt with pause and resume."""
+class ExamDialog(QDialog):
+    """Modal dialog showing an ongoing exam attempt with pause and resume."""
 
     def __init__(self, attempt: Attempt, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self.setWindowModality(Qt.ApplicationModal)
         self.attempt = attempt
         self.remaining_seconds = attempt.time_limit * 60
         self.index = 0
@@ -224,18 +225,16 @@ class ExamWindow(QWidget):
 
         def _show() -> None:
             ResultsDialog.show_for_attempt(self.attempt, self)
-            self.close()
+            self.accept()
 
         QTimer.singleShot(0, _show)
 
 
-def start_exam(config: ExamConfig, parent: QWidget | None = None) -> ExamWindow:
+def start_exam(config: ExamConfig, parent: QWidget | None = None) -> bool:
+    """Launch a modal exam dialog and return True if completed."""
     attempt = create_attempt(config)
-    win = ExamWindow(attempt, parent)
-    win.show()
-    win.raise_()
-    win.activateWindow()
-    return win
+    dlg = ExamDialog(attempt, parent)
+    return dlg.exec() == QDialog.Accepted
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -246,6 +245,6 @@ if __name__ == "__main__":  # pragma: no cover
     app = QApplication(sys.argv)
     dlg = ExamConfigDialog()
     if dlg.exec() == dlg.Accepted and dlg.config:
-        win = start_exam(dlg.config)
+        start_exam(dlg.config)
         print("Botón Pausar disponible")
         sys.exit(app.exec())


### PR DESCRIPTION
## Notes
- Transforms the exam window into a `QDialog` so exams run modally and return a result.
- Main window simplified as open dialog no longer tracked.

## Summary
- Renamed `ExamWindow` to `ExamDialog` and made it modal
- Updated `start_exam` helper to return `bool`
- Removed `_open_exams` logic from `MainWindow`
- Adjusted imports and `__all__`

## Testing
- `ruff check .` *(fails: 17 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d966164888329aee31fafe784d93a