### PR TITLE
feat(gui): match ExamDialog size to parent

### DIFF
--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -121,6 +121,12 @@ class ExamDialog(QDialog):
 
         self._load_question()
 
+        if parent:
+            self.resize(parent.size())
+            self.move(parent.pos())
+        else:
+            self.resize(1024, 768)
+
     # ------------------------ helpers ---------------------
     @staticmethod
     def _fmt(secs: int) -> str:


### PR DESCRIPTION
## Summary
- ensure `ExamDialog` adopts main window size and position

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d9849d5788329874526fb7f5e9f62