### PR TITLE
Keep custom colors on disabled options

### DIFF
--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -265,9 +265,19 @@ class ExamDialog(QDialog):
         sel_set = set(aq.selected_option or "")
         for w in self.opts:
             if w.is_correct:
-                w.setStyleSheet("color: lightgreen;")
+                w.setStyleSheet(
+                    "QCheckBox,QRadioButton { color: lightgreen; }"
+                    "QCheckBox::indicator:disabled,"
+                    "QRadioButton::indicator:disabled {"
+                    "  background: lightgreen; border: 1px solid lightgreen; }"
+                )
             elif w.letter in sel_set:
-                w.setStyleSheet("color: salmon;")
+                w.setStyleSheet(
+                    "QCheckBox,QRadioButton { color: salmon; }"
+                    "QCheckBox::indicator:disabled,"
+                    "QRadioButton::indicator:disabled {"
+                    "  background: salmon; border: 1px solid salmon; }"
+                )
             else:
                 w.setStyleSheet("")
 


### PR DESCRIPTION
## Summary
- ensure text + indicators keep their colors when disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ee455b0a083299fa4e4a04b0220b1