### PR TITLE
fix(gui): persistent colours via dynamic properties

### DIFF
--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -272,9 +272,14 @@ class ExamDialog(QDialog):
 
         for w in self.opts:
             if w.is_correct:
-                w.setStyleSheet("color: lightgreen;")
+                w.setProperty("state", "correct")
             elif w.letter in sel_set:
-                w.setStyleSheet("color: salmon;")
+                w.setProperty("state", "wrong")
+            else:
+                w.setProperty("state", "")
+            w.style().unpolish(w)
+            w.style().polish(w)
+            w.update()
 
     def _load_question(self) -> None:
         self._update_timer()

--- a/examgen/ui/styles.py
+++ b/examgen/ui/styles.py
@@ -16,6 +16,18 @@ QDialogButtonBox > QPushButton:disabled {
     background-color: #9e9e9e;          /* gris claro */
     color: #ededed;
 }
+
+/* ---- dynamic state colours ---- */
+QAbstractButton[state="correct"]  { color: lightgreen; }
+QAbstractButton[state="wrong"]    { color: salmon; }
+QAbstractButton[state="correct"]::indicator:checked,
+QAbstractButton[state="correct"]::indicator:checked:disabled {
+    background: lightgreen; border: 1px solid lightgreen;
+}
+QAbstractButton[state="wrong"]::indicator:checked,
+QAbstractButton[state="wrong"]::indicator:checked:disabled {
+    background: salmon; border: 1px solid salmon;
+}
 """
 
 


### PR DESCRIPTION
## Summary
- add state-based coloring to the global QSS
- reimplement `_apply_colors` using dynamic properties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f0bbc5fe88329ba657d7c8596c12a