### PR TITLE
Render answer colours as rich-text

### DIFF
--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -277,6 +277,8 @@ class ExamDialog(QDialog):
                 w.setText(f"<font color='{color}'>{w.raw_text}</font>")
             else:
                 w.setText(w.raw_text)
+            w.setTextFormat(Qt.RichText)
+            w.adjustSize()
 
             w.setAttribute(Qt.WA_TransparentForMouseEvents, True)
             w.setFocusPolicy(Qt.NoFocus)


### PR DESCRIPTION
## Notes
- After setting text for each option in `_apply_colors`, we now enforce rich-text rendering and resize the widget.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f14f5bf088329852662d07dd4ae04