### PR TITLE
Fix improper use of setTextFormat in widgets

### DIFF
--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -274,10 +274,10 @@ class ExamDialog(QDialog):
                 color = "#ff6b6b"  # rojo
 
             if color:
-                w.setText(f"<font color='{color}'>{w.raw_text}</font>")
+                w.setStyleSheet(f"color: {color};")
             else:
-                w.setText(w.raw_text)
-            w.setTextFormat(Qt.RichText)
+                w.setStyleSheet("")
+            w.setText(w.raw_text)
             w.adjustSize()
 
             w.setAttribute(Qt.WA_TransparentForMouseEvents, True)


### PR DESCRIPTION
## Summary
- remove invalid call to `setTextFormat` for checkboxes/radio buttons
- color answers using CSS instead of rich text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f163fbe70832982eec30e84f9596f