### PR TITLE
fix(gui): save selection before coloring answers

### DIFF
--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -379,6 +379,7 @@ class ExamDialog(QDialog):
 
     def on_toggle_clicked(self) -> None:
         if not self.expl_shown:
+            self._save_selection()
             self._evaluate_selection(self.current_aq)
             self._apply_colors(self.current_aq)
             self._freeze_options()


### PR DESCRIPTION
## Summary
- save the user's choice before applying answer colors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f2c981dc08329be9f9d46d082f7d0