### PR TITLE
Compact layout & per-option explanations

### DIFF
--- a/examgen/models.py
+++ b/examgen/models.py
@@ -103,6 +103,11 @@ class Question(Base):
 
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "BASE"}
 
+    @property
+    def options_dict(self) -> dict[str, "AnswerOption"]:
+        """Return a mapping letter→AnswerOption for quick access."""
+        return {letter: opt for letter, opt in zip("ABCDE", self.options)}
+
 
 class MCQQuestion(Question):
     __mapper_args__ = {"polymorphic_identity": "MCQ"}

--- a/examgen/ui/styles.py
+++ b/examgen/ui/styles.py
@@ -30,7 +30,16 @@ QAbstractButton[state="wrong"]::indicator:checked:disabled {
 }
 """
 
+OPTION_EXPL_STYLE = """
+QLabel#OptExplanation {
+    color: #b5b5b5;
+    font-style: italic;
+    margin-left: 28px;
+    margin-bottom: 8px;
+}
+"""
+
 
 def apply_app_styles(app: QApplication) -> None:
     """Apply global styles to *app*."""
-    app.setStyleSheet(BUTTON_STYLE)
+    app.setStyleSheet(BUTTON_STYLE + OPTION_EXPL_STYLE)


### PR DESCRIPTION
## Summary
- remove global explanation panel for exam questions
- show explanation per option inside `ExamDialog`
- tweak global style for option explanations
- expose `Question.options_dict` helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f33fe54408329b5fdb397b56606d6