### PR TITLE
Migrate ExamConfigDialog to ui

### DIFF
--- a/examgen/gui/ui/ExamConfigDialog.ui
+++ b/examgen/gui/ui/ExamConfigDialog.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExamConfigDialog</class>
+ <widget class="QDialog" name="ExamConfigDialog">
+  <property name="windowTitle">
+   <string>Configurar examen</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_subject">
+       <property name="text">
+        <string>Materia:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cb_subject">
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_time">
+       <property name="text">
+        <string>Tiempo límite (min):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="spin_time">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>999</number>
+       </property>
+       <property name="value">
+        <number>90</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_questions">
+       <property name="text">
+        <string>Nº preguntas:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QSpinBox" name="spin_questions">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>999</number>
+       </property>
+       <property name="value">
+        <number>60</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_selector">
+       <property name="text">
+        <string>Selector:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QWidget" name="widget_radio">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="contentsMargins">
+         <left>0</left>
+         <top>0</top>
+         <right>0</right>
+         <bottom>0</bottom>
+        </property>
+        <item>
+         <widget class="QRadioButton" name="rb_random">
+          <property name="text">
+           <string>Aleatorio</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rb_errors">
+          <property name="text">
+           <string>Errores</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="lbl_no_subjects">
+     <property name="text">
+      <string>No hay materias disponibles. Importe preguntas primero.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="styleSheet">
+      <string>color: gray</string>
+     </property>
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- load ExamConfigDialog from Qt Designer ui file
- add `.ui` layout replicating previous widgets

## Testing
- `black examgen/gui/dialogs.py`
- `mypy examgen/gui/dialogs.py` *(fails: Invalid type ignore)*
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68443eec6d90832996a28c77b13664e1