### PR TITLE
Fix margin properties in ExamConfigDialog UI

### DIFF
--- a/examgen/gui/ui/ExamConfigDialog.ui
+++ b/examgen/gui/ui/ExamConfigDialog.ui
@@ -72,11 +72,17 @@
      <item row="3" column="1">
       <widget class="QWidget" name="widget_radio">
        <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="contentsMargins">
-         <left>0</left>
-         <top>0</top>
-         <right>0</right>
-         <bottom>0</bottom>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
         </property>
         <item>
          <widget class="QRadioButton" name="rb_random">


### PR DESCRIPTION
## Summary
- correct invalid `contentsMargins` tag in `ExamConfigDialog.ui`

## Testing
- `xmllint --noout examgen/gui/ui/ExamConfigDialog.ui`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68444989b730832984974c50213a6957