### PR TITLE
Migrate QuestionDialog to Qt Designer (.ui)

### DIFF
--- a/examgen/gui/dialogs.py
+++ b/examgen/gui/dialogs.py
@@ -7,7 +7,6 @@ from PySide6.QtGui import QIcon, QTextOption, QColor
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import QLineEdit
 from PySide6.QtWidgets import (
-    QCheckBox,
     QComboBox,
     QButtonGroup,
     QDialog,
@@ -21,15 +20,13 @@ from PySide6.QtWidgets import (
     QPlainTextEdit,
     QTableWidget,
     QTableWidgetItem,
-    QToolButton,
-    QHeaderView,
     QHBoxLayout,
     QVBoxLayout,
     QWidget,
-    QStyledItemDelegate,
-    QStyleOptionViewItem,
     QCompleter,
 )
+
+from examgen.gui.widgets import OptionTable
 
 from examgen import models as m
 from examgen.models import SessionLocal
@@ -44,148 +41,6 @@ from examgen.services.exam_service import (
 DB_PATH = Path("examgen.db")
 MAX_CHARS = 3000
 MIN_ROWS = 4
-
-
-# ------------------------------------------------------------------
-# Delegate that wraps text even without spaces
-# ------------------------------------------------------------------
-class WrapAnywhereDelegate(QStyledItemDelegate):
-    _flags = Qt.TextWordWrap | Qt.TextWrapAnywhere
-
-    def initStyleOption(self, option: QStyleOptionViewItem, index):  # type: ignore[override]
-        super().initStyleOption(option, index)
-        option.textElideMode = Qt.ElideNone
-        option.displayAlignment = Qt.AlignLeft | Qt.AlignVCenter
-
-    def sizeHint(self, option: QStyleOptionViewItem, index):  # type: ignore[override]
-        size = super().sizeHint(option, index)
-        min_h = option.fontMetrics.lineSpacing() + 6
-        size.setHeight(max(size.height(), min_h))
-        return size
-
-    def paint(self, painter, option, index):  # type: ignore[override]
-        self.initStyleOption(option, index)
-        painter.save()
-        painter.drawText(
-            option.rect, self._flags, str(index.data(Qt.DisplayRole) or "")
-        )
-        painter.restore()
-
-
-# ------------------------------------------------------------------
-# OptionTable
-# ------------------------------------------------------------------
-class OptionTable(QTableWidget):
-    HEADER = ["", "Opción", "Correcta", "Respuesta", "Explicación", ""]
-
-    def __init__(self, parent: QWidget | None = None):
-        super().__init__(MIN_ROWS, 6, parent)
-
-        # header setup
-        self.setHorizontalHeaderLabels(self.HEADER)
-        hh = self.horizontalHeader()
-        hh.setSectionResizeMode(0, QHeaderView.ResizeToContents)
-        hh.setSectionResizeMode(1, QHeaderView.Stretch)
-        hh.resizeSection(2, 80)
-        hh.setSectionResizeMode(3, QHeaderView.Stretch)
-        hh.setSectionResizeMode(4, QHeaderView.Stretch)
-        hh.resizeSection(5, 40)
-        hh.setStretchLastSection(False)
-
-        self.verticalHeader().setVisible(False)
-        self.verticalHeader().setDefaultSectionSize(
-            self.fontMetrics().lineSpacing() + 6
-        )
-        self.setWordWrap(True)
-
-        wrap = WrapAnywhereDelegate(self)
-        for c in (1, 3, 4):
-            self.setItemDelegateForColumn(c, wrap)
-
-        for r in range(MIN_ROWS):
-            self._init_row(r)
-        self._refresh_delete_buttons()
-        self.resizeRowsToContents()
-
-        self.cellChanged.connect(self._auto_height)
-
-    # ------------ row helpers -----------------
-    def _init_row(self, row: int):
-        letter = QTableWidgetItem(chr(ord("a") + row))
-        letter.setFlags(Qt.ItemIsEnabled)
-        letter.setTextAlignment(Qt.AlignCenter)
-        self.setItem(row, 0, letter)
-
-        for col in (1, 3, 4):
-            self.setItem(row, col, QTableWidgetItem(""))
-
-        cb = QCheckBox()
-        wrap = QWidget()
-        lay = QHBoxLayout(wrap)
-        lay.setContentsMargins(0, 0, 0, 0)
-        lay.addStretch(1)
-        lay.addWidget(cb)
-        lay.addStretch(1)
-        self.setCellWidget(row, 2, wrap)
-
-        trash = QToolButton()
-        trash.setIcon(QIcon.fromTheme("edit-delete"))
-        trash.setAutoRaise(True)
-        trash.clicked.connect(lambda *_: self._remove_row(row))
-        self.setCellWidget(row, 5, trash)
-
-    def add_row(self):
-        r = self.rowCount()
-        self.insertRow(r)
-        self._init_row(r)
-        self._refresh_letters()
-        self._refresh_delete_buttons()
-        self.resizeRowsToContents()
-
-    def _remove_row(self, row: int):
-        if self.rowCount() > MIN_ROWS:
-            self.removeRow(row)
-            self._refresh_letters()
-            self._refresh_delete_buttons()
-            self.resizeRowsToContents()
-
-    def _refresh_letters(self):
-        for r in range(self.rowCount()):
-            self.item(r, 0).setText(chr(ord("a") + r))
-
-    def _refresh_delete_buttons(self):
-        allow = self.rowCount() > MIN_ROWS
-        for r in range(self.rowCount()):
-            btn: QToolButton | None = self.cellWidget(r, 5).findChild(QToolButton)  # type: ignore
-            if btn:
-                btn.setEnabled(allow)
-
-    def _auto_height(self, row: int, _col: int):
-        self.resizeRowToContents(row)
-
-    # ------------ collect ---------------------
-    def collect(self) -> tuple[List[m.AnswerOption], int]:
-        opts: List[m.AnswerOption] = []
-        correct = 0
-        for r in range(self.rowCount()):
-            text = self.item(r, 1).text().strip()
-            if not text:
-                continue
-            text = text[:MAX_CHARS]
-            answer = self.item(r, 3).text().strip()[:MAX_CHARS]
-            expl = self.item(r, 4).text().strip()[:MAX_CHARS]
-            is_corr = self.cellWidget(r, 2).findChild(QCheckBox).isChecked()  # type: ignore
-            if is_corr:
-                correct += 1
-            opts.append(
-                m.AnswerOption(
-                    text=text,
-                    answer=answer or None,
-                    explanation=expl or None,
-                    is_correct=is_corr,
-                )
-            )
-        return opts, correct
 
 
 # ------------------------------------------------------------------
@@ -301,57 +156,28 @@ class QuestionDialog(QDialog):
     def __init__(self, parent: QWidget | None = None, *, db_path: Path = DB_PATH):
         super().__init__(parent)
         self.db_path = db_path
-        self.setWindowTitle("Nueva pregunta – MCQ")
-        self.resize(1920, 1080)
+        ui_file = QFile("examgen/gui/ui/QuestionDialog.ui")
+        ui_file.open(QIODevice.ReadOnly)
+        QUiLoader().load(ui_file, self)
+        ui_file.close()
 
-        # subject / reference
-        self.cb_subject = QComboBox(editable=True, fixedWidth=500)
-        self.le_reference = QLineEdit()
-        self.le_reference.setPlaceholderText("ej.: exam_1025")
+        self.buttons: QDialogButtonBox = self.findChild(QDialogButtonBox, "buttons")
+        self.btn_ok: QPushButton = self.buttons.button(QDialogButtonBox.Save)
+        self.cb_subject: QComboBox = self.findChild(QComboBox, "cb_subject")
+        self.le_reference: QLineEdit = self.findChild(QLineEdit, "le_reference")
+        self.prompt: QPlainTextEdit = self.findChild(QPlainTextEdit, "prompt")
+        self.counter: QLabel = self.findChild(QLabel, "counter")
+        self.table: OptionTable = self.findChild(OptionTable, "table")
+        self.btn_add: QPushButton = self.findChild(QPushButton, "btn_add")
 
-        top = QHBoxLayout()
-        top.setContentsMargins(0, 0, 0, 0)
-        top.addWidget(self.cb_subject)
-        top.addSpacing(20)
-        top.addWidget(QLabel("Referencia:"))
-        top.addWidget(self.le_reference)
-        w_top = QWidget()
-        w_top.setLayout(top)
-
-        # prompt
-        self.prompt = QPlainTextEdit()
-        self.prompt.setWordWrapMode(QTextOption.WrapMode.WordWrap)
-        self.counter = QLabel("0/3000", alignment=Qt.AlignRight)
+        self.buttons.rejected.connect(self.reject)
+        self.btn_ok.clicked.connect(self.accept)
         self.prompt.textChanged.connect(self._update_counter)
+        if self.btn_add is not None:
+            self.btn_add.clicked.connect(self.table.add_row)
 
-        w_prompt = QWidget()
-        hp = QHBoxLayout(w_prompt)
-        hp.setContentsMargins(0, 0, 0, 0)
-        hp.addWidget(self.prompt)
-
-        # table options
-        self.table = OptionTable(self)
-        add_btn = QPushButton("+", clicked=self.table.add_row, fixedSize=QSize(30, 30))
-
-        form = QFormLayout()
-        form.addRow("Materia:", w_top)
-        form.addRow("Enunciado:", w_prompt)
-        form.addRow("", self.counter)
-        form.addRow(QLabel("Opciones (texto, explicación, correcta):"))
-        form.addRow(self.table)
-        h = QHBoxLayout()
-        h.addWidget(add_btn)
-        h.addStretch(1)
-        form.addRow(h)
-
-        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
-
-        root = QVBoxLayout(self)
-        root.addLayout(form)
-        root.addWidget(buttons)
         self._load_subjects()
+        self._update_counter()
 
     # ---------------- helpers -----------------
     def _update_counter(self):

--- a/examgen/gui/ui/QuestionDialog.ui
+++ b/examgen/gui/ui/QuestionDialog.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QuestionDialog</class>
+ <widget class="QDialog" name="QuestionDialog">
+  <property name="windowTitle">
+   <string>Nueva pregunta – MCQ</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_subject">
+       <property name="text">
+        <string>Materia:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QWidget" name="w_top">
+       <layout class="QHBoxLayout" name="layout_top">
+        <property name="leftMargin"><number>0</number></property>
+        <property name="topMargin"><number>0</number></property>
+        <property name="rightMargin"><number>0</number></property>
+        <property name="bottomMargin"><number>0</number></property>
+        <item>
+         <widget class="QComboBox" name="cb_subject">
+          <property name="editable"><bool>true</bool></property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="spacer1">
+          <property name="orientation"><enum>Qt::Horizontal</enum></property>
+          <property name="sizeHint" stdset="0">
+           <size><width>20</width><height>20</height></size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_reference">
+          <property name="text"><string>Referencia:</string></property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="le_reference">
+          <property name="placeholderText"><string>ej.: exam_1025</string></property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_prompt">
+       <property name="text"><string>Enunciado:</string></property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPlainTextEdit" name="prompt"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="counter">
+       <property name="text"><string>0/3000</string></property>
+       <property name="alignment"><set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set></property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QLabel" name="label_opts">
+       <property name="text">
+        <string>Opciones (texto, explicación, correcta):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="2">
+      <widget class="OptionTable" name="table"/>
+     </item>
+     <item row="5" column="0" colspan="2">
+      <layout class="QHBoxLayout" name="layout_add">
+       <property name="leftMargin"><number>0</number></property>
+       <property name="topMargin"><number>0</number></property>
+       <property name="rightMargin"><number>0</number></property>
+       <property name="bottomMargin"><number>0</number></property>
+       <item>
+        <widget class="QPushButton" name="btn_add">
+         <property name="text"><string>+</string></property>
+         <property name="minimumSize"><size><width>30</width><height>30</height></size></property>
+         <property name="maximumSize"><size><width>30</width><height>30</height></size></property>
+        </widget>
+       </item>
+       <item><spacer name="spacer2">
+         <property name="orientation"><enum>Qt::Horizontal</enum></property>
+         <property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property>
+       </spacer></item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Save|QDialogButtonBox::Cancel</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>OptionTable</class>
+   <extends>QTableWidget</extends>
+   <header>examgen/gui/widgets</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- move OptionTable widget logic to `widgets.py`
- remove manual widget setup in QuestionDialog
- add new `QuestionDialog.ui`
- load `.ui` in QuestionDialog and wire signals

## Testing
- `pytest` *(fails: ImportError: libEGL.so.1)*
- `python -m examgen.gui.main` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68444e8dc54483299ddbeb389bac9f42