### PR TITLE
Add OptionTable and row controls to QuestionDialog

### DIFF
--- a/examgen/gui/dialogs.py
+++ b/examgen/gui/dialogs.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
     QPlainTextEdit,
     QTableWidget,
     QTableWidgetItem,
+    QToolButton,
     QHBoxLayout,
     QVBoxLayout,
     QWidget,
@@ -167,14 +168,17 @@ class QuestionDialog(QDialog):
         self.le_reference: QLineEdit = self.findChild(QLineEdit, "le_reference")
         self.prompt: QPlainTextEdit = self.findChild(QPlainTextEdit, "prompt")
         self.counter: QLabel = self.findChild(QLabel, "counter")
-        self.table: OptionTable = self.findChild(OptionTable, "table")
-        self.btn_add: QPushButton = self.findChild(QPushButton, "btn_add")
+        self.tbl_options: OptionTable = self.findChild(OptionTable, "tbl_options")
+        self.btn_add: QToolButton = self.findChild(QToolButton, "btn_add")
+        self.btn_del: QToolButton = self.findChild(QToolButton, "btn_del")
 
         self.buttons.rejected.connect(self.reject)
         self.btn_ok.clicked.connect(self.accept)
         self.prompt.textChanged.connect(self._update_counter)
         if self.btn_add is not None:
-            self.btn_add.clicked.connect(self.table.add_row)
+            self.btn_add.clicked.connect(self._add_row)
+        if self.btn_del is not None:
+            self.btn_del.clicked.connect(self._del_row)
 
         self._load_subjects()
         self._update_counter()
@@ -194,6 +198,14 @@ class QuestionDialog(QDialog):
         self.cb_subject.addItems(names)
         self.cb_subject.setPlaceholderText("Seleccione / escriba…")
 
+    def _add_row(self) -> None:
+        self.tbl_options.insertRow(self.tbl_options.rowCount())
+
+    def _del_row(self) -> None:
+        r = self.tbl_options.currentRow()
+        if r >= 0:
+            self.tbl_options.removeRow(r)
+
     # ---------------- guardar -----------------
     def accept(self):  # type: ignore[override]  noqa: D401
         subj = self.cb_subject.currentText().strip()
@@ -206,7 +218,7 @@ class QuestionDialog(QDialog):
             )
             return
 
-        options, correct = self.table.collect()
+        options, correct = self.tbl_options.collect()
         if len(options) < 2 or correct == 0:
             QMessageBox.warning(
                 self,

--- a/examgen/gui/ui/QuestionDialog.ui
+++ b/examgen/gui/ui/QuestionDialog.ui
@@ -70,7 +70,14 @@
       </widget>
      </item>
      <item row="4" column="0" colspan="2">
-      <widget class="OptionTable" name="table"/>
+      <widget class="OptionTable" name="tbl_options">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
      </item>
      <item row="5" column="0" colspan="2">
       <layout class="QHBoxLayout" name="layout_add">
@@ -79,16 +86,21 @@
        <property name="rightMargin"><number>0</number></property>
        <property name="bottomMargin"><number>0</number></property>
        <item>
-        <widget class="QPushButton" name="btn_add">
+        <widget class="QToolButton" name="btn_add">
          <property name="text"><string>+</string></property>
-         <property name="minimumSize"><size><width>30</width><height>30</height></size></property>
-         <property name="maximumSize"><size><width>30</width><height>30</height></size></property>
         </widget>
        </item>
-       <item><spacer name="spacer2">
+       <item>
+        <widget class="QToolButton" name="btn_del">
+         <property name="text"><string>–</string></property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="spacer2">
          <property name="orientation"><enum>Qt::Horizontal</enum></property>
          <property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property>
-       </spacer></item>
+        </spacer>
+       </item>
       </layout>
      </item>
     </layout>


### PR DESCRIPTION
## Summary
- update QuestionDialog UI with OptionTable and add/del buttons
- hook up new buttons in `QuestionDialog` logic

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684455a7b47083298b0fe138224df19a