### PR TITLE
Add unique() to evaluate_attempt query

### DIFF
--- a/examgen/services/exam_service.py
+++ b/examgen/services/exam_service.py
@@ -187,7 +187,8 @@ def evaluate_attempt(attempt_id: int) -> Attempt:
             .options(joinedload(Attempt.questions).joinedload(AttemptQuestion.question))
             .filter_by(id=attempt_id)
         )
-        attempt = session.scalars(stmt).one()
+        # .unique() necesario por joined eager-load de colecciones
+        attempt = session.scalars(stmt).unique().one()
 
         total = 0
         for aq in attempt.questions:


### PR DESCRIPTION
## Summary
- ensure single Attempt row is loaded when evaluating

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684462ff741c8329b8f5be5626eea585