### PR TITLE
Avoid DetachedInstanceError by eager-loading question

### DIFF
--- a/examgen/services/exam_service.py
+++ b/examgen/services/exam_service.py
@@ -166,12 +166,14 @@ def create_attempt(config: ExamConfig) -> Attempt:
 
         session.commit()
 
+        q_poly = with_polymorphic(m.Question, "*")
+
         attempt = (
             session.query(Attempt)
             .options(
                 selectinload(Attempt.questions)
-                .selectinload(AttemptQuestion.question)
-                .selectinload(Question.options)
+                .selectinload(AttemptQuestion.question.of_type(q_poly))
+                .selectinload(q_poly.MCQQuestion.options)
             )
             .filter_by(id=attempt.id)
             .one()


### PR DESCRIPTION
## Summary
- eager-load `AttemptQuestion.question` with polymorphic query in `create_attempt`

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6844699493088329892ad0a9c8ee1fd4