### PR TITLE
feat(gui): improve results dialog layout

### DIFF
--- a/examgen/gui/dialogs.py
+++ b/examgen/gui/dialogs.py
@@ -455,35 +455,52 @@ class ResultsDialog(QDialog):
             alignment=Qt.AlignCenter,
         )
 
-        table = QTableWidget(len(attempt.questions), 4, self)
-        table.setHorizontalHeaderLabels(["#", "Pregunta", "Tu resp.", "Correcta"])
-        table.horizontalHeader().setStretchLastSection(True)
-        table.verticalHeader().setVisible(False)
+        self.table = QTableWidget(len(attempt.questions), 4, self)
+        self.table.setHorizontalHeaderLabels(["#", "Pregunta", "Tu resp.", "Correcta"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.verticalHeader().setVisible(False)
+        self.table.setTextElideMode(Qt.ElideRight)
+        self.table.setMinimumWidth(700)
+
+        correct_bg = QColor("#5af16a")
+        correct_fg = QColor("#000000")
+        wrong_bg = QColor("#ff6b6b")
+        wrong_fg = QColor("#ffffff")
 
         for row, aq in enumerate(attempt.questions, start=0):
             qitem = QTableWidgetItem(str(row + 1))
             qitem.setFlags(Qt.ItemIsEnabled)
             qitem.setTextAlignment(Qt.AlignCenter)
-            table.setItem(row, 0, qitem)
+            self.table.setItem(row, 0, qitem)
 
-            prompt = aq.question.prompt[:60]
+            prompt = aq.question.prompt
             pitem = QTableWidgetItem(prompt)
             pitem.setFlags(Qt.ItemIsEnabled)
-            table.setItem(row, 1, pitem)
+            pitem.setToolTip(prompt)
+            self.table.setItem(row, 1, pitem)
 
             sel_text = aq.selected_option or ""
             sitem = QTableWidgetItem(sel_text)
             sitem.setFlags(Qt.ItemIsEnabled)
-            table.setItem(row, 2, sitem)
+            sitem.setToolTip(sel_text)
+            self.table.setItem(row, 2, sitem)
 
             corr_text = next((o.text for o in aq.question.options if o.is_correct), "")
             citem = QTableWidgetItem(corr_text)
             citem.setFlags(Qt.ItemIsEnabled)
-            table.setItem(row, 3, citem)
+            citem.setToolTip(corr_text)
+            self.table.setItem(row, 3, citem)
 
-            color = QColor("lightgreen") if aq.is_correct else QColor("salmon")
+            if aq.is_correct:
+                bg = correct_bg
+                fg = correct_fg
+            else:
+                bg = wrong_bg
+                fg = wrong_fg
             for c in range(4):
-                table.item(row, c).setBackground(color)
+                cell = self.table.item(row, c)
+                cell.setBackground(bg)
+                cell.setForeground(fg)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Close, parent=self)
         buttons.rejected.connect(self.reject)
@@ -491,8 +508,10 @@ class ResultsDialog(QDialog):
         root = QVBoxLayout(self)
         root.addWidget(title)
         root.addWidget(summary)
-        root.addWidget(table)
+        root.addWidget(self.table)
         root.addWidget(buttons, alignment=Qt.AlignCenter)
+
+        self.resize(self.width() + 120, self.height())
 
     @classmethod
     def show_for_attempt(cls, attempt: Attempt, parent: QWidget | None = None) -> None:


### PR DESCRIPTION
## Summary
- enlarge results dialog width
- make table width consistent and adjust colors
- show full text with elide and tooltips for cells

## Testing
- `python3 -m py_compile examgen/gui/dialogs.py`
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68447cf770048329bab84526d32db941