### PR TITLE
Add attempts history dialog

### DIFF
--- a/examgen/gui/main.py
+++ b/examgen/gui/main.py
@@ -112,6 +112,9 @@ class MainWindow(QMainWindow):
         new_question_action = QAction("Nueva &pregunta…", self)
         new_question_action.triggered.connect(self._open_question_dialog)
         archivo.addAction(new_question_action)
+        history_action = QAction("Historial", self)
+        history_action.triggered.connect(self._show_history)
+        archivo.addAction(history_action)
         archivo.addSeparator()
         archivo.addAction("Salir", QApplication.instance().quit)
 
@@ -173,6 +176,10 @@ class MainWindow(QMainWindow):
         if QuestionDialog(self, db_path=DB_PATH).exec():
             self._update_subject_count()
             self._update_status()
+
+    def _show_history(self) -> None:
+        from examgen.gui.dialogs import AttemptsHistoryDialog
+        AttemptsHistoryDialog(self).exec()
 
 
 # ------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- implement `AttemptsHistoryDialog` to list past attempts
- integrate new `Historial` action in the main menu

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68448f14f9e08329ab563d53106a89b9