### PR TITLE
Fix attempt scoring and timing persistence

### DIFF
--- a/examgen/gui/widgets.py
+++ b/examgen/gui/widgets.py
@@ -410,6 +410,12 @@ class ExamDialog(QDialog):
             self.timer.stop()
         self._save_selection()
         self.attempt.ended_at = datetime.utcnow()
+
+        from examgen.models import SessionLocal
+        with SessionLocal() as s:
+            s.merge(self.attempt)
+            s.commit()
+
         self.attempt = evaluate_attempt(self.attempt.id)
 
         def _show() -> None:


### PR DESCRIPTION
## Summary
- persist `ended_at` before evaluating attempts
- compute attempt score and correctness in one session

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844940ce1888329982b5a4520c5b6bd