### PR TITLE
Simplify preload of attempt questions

### DIFF
--- a/examgen/services/exam_service.py
+++ b/examgen/services/exam_service.py
@@ -210,11 +210,7 @@ def evaluate_attempt(attempt_id: int) -> m.Attempt:
     with SessionLocal() as s:
         attempt = (
             s.query(m.Attempt)
-            .options(
-                selectinload(m.Attempt.questions)
-                .selectinload(m.AttemptQuestion.question)
-                .selectinload(m.MCQQuestion.options)
-            )
+            .options(selectinload(m.Attempt.questions))
             .get(attempt_id)
         )
         if not attempt:


### PR DESCRIPTION
## Summary
- avoid nested `selectinload` chain in `evaluate_attempt`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6844987fdbac832991970cd5bd625aad