### PR TITLE
Fix MCQ option loading in ResultsDialog

### DIFF
--- a/examgen/gui/dialogs.py
+++ b/examgen/gui/dialogs.py
@@ -514,11 +514,13 @@ class ResultsDialog(QDialog):
     def show_for_attempt(cls, attempt: Attempt, parent: QWidget | None = None) -> None:
         session = SessionLocal()
         attempt_db = (
-            session.query(Attempt)
+            session.query(m.Attempt)
             .options(
-                selectinload(Attempt.questions)
-                .joinedload(m.AttemptQuestion.question)
-                .joinedload(m.MCQQuestion.options)
+                selectinload(m.Attempt.questions)
+                .joinedload(
+                    m.AttemptQuestion.question.of_type(m.MCQQuestion)
+                )
+                .selectinload(m.MCQQuestion.options)
             )
             .get(attempt.id)
         )


### PR DESCRIPTION
## Summary
- load MCQ options using `of_type` when reloading `Attempt`

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6844a04a8ca4832992cd26743cec39fe