### PR TITLE
Fix stats position in status bar

### DIFF
--- a/examgen/gui/main.py
+++ b/examgen/gui/main.py
@@ -75,7 +75,8 @@ class MainWindow(QMainWindow):
         self._create_menu_bar()
         self._create_status_bar()
         self.lbl_stats = QLabel(self)
-        self.statusBar().addPermanentWidget(self.lbl_stats)
+        self.statusBar().addWidget(self.lbl_stats)
+        self.lbl_stats.setContentsMargins(4, 0, 0, 0)
         self._refresh_stats()
 
     # --------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- ensure stats text stays on the left side of the status bar

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6844a72b3ed08329888b5913a0f6ecf8