### PR TITLE
Hide statusbar item borders

### DIFF
--- a/examgen/gui/main.py
+++ b/examgen/gui/main.py
@@ -141,6 +141,9 @@ class MainWindow(QMainWindow):
     def _create_status_bar(self) -> None:
         sb = QStatusBar(self)
         self.setStatusBar(sb)
+        sb = self.statusBar()
+        # Oculta el borde que QT dibuja en cada item del status-bar
+        sb.setStyleSheet("QStatusBar::item { border: 0px solid transparent; }")
 
     def _refresh_stats(self) -> None:
         with SessionLocal() as s:


### PR DESCRIPTION
## Summary
- hide default item borders in `MainWindow`'s status bar

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844a8cd66bc83298676e6ae289e07d3