### PR TITLE
Add questions management window

### DIFF
--- a/examgen/gui/main.py
+++ b/examgen/gui/main.py
@@ -3,7 +3,7 @@ examgen/gui/main.py – Ventana principal de ExamGen con selector de tema.
 
 • El tema *Oscuro* se aplica al arrancar.
 • Menú “Tema” permite cambiar entre Claro y Oscuro en caliente.
-• Menú “Archivo” incluye “Nueva pregunta…”.
+• Menú “Archivo” incluye “Preguntas…”.
 """
 
 from __future__ import annotations
@@ -112,9 +112,9 @@ class MainWindow(QMainWindow):
         exam_action.triggered.connect(_do_exam)
         archivo.addAction(exam_action)
 
-        new_question_action = QAction("Nueva &pregunta…", self)
-        new_question_action.triggered.connect(self._open_question_dialog)
-        archivo.addAction(new_question_action)
+        act_questions = QAction("Preguntas", self)
+        act_questions.triggered.connect(self._show_questions)
+        archivo.addAction(act_questions)
         history_action = QAction("Historial", self)
         history_action.triggered.connect(self._show_history)
         archivo.addAction(history_action)
@@ -175,8 +175,18 @@ class MainWindow(QMainWindow):
         if QuestionDialog(self, db_path=DB_PATH).exec():
             self._refresh_stats()
 
+    def _show_questions(self) -> None:
+        from examgen.gui.questions_window import QuestionsWindow
+
+        if not hasattr(self, "_questions_win") or self._questions_win is None:
+            self._questions_win = QuestionsWindow(self)
+        self._questions_win.show()
+        self._questions_win.raise_()
+        self._questions_win.activateWindow()
+
     def _show_history(self) -> None:
         from examgen.gui.dialogs import AttemptsHistoryDialog
+
         AttemptsHistoryDialog(self).exec()
 
 

--- a/examgen/gui/questions_window.py
+++ b/examgen/gui/questions_window.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QComboBox,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+    QMessageBox,
+)
+from PySide6.QtCore import Qt
+
+from examgen import models as m
+from examgen.models import SessionLocal
+from examgen.gui.dialogs import QuestionDialog
+
+
+class QuestionsWindow(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Preguntas")
+        if parent is not None:
+            self.resize(parent.size())
+
+        # --- fila 1: filtros + botón ---
+        self.cb_subject = QComboBox()
+        self.cb_subject.currentIndexChanged.connect(self._load_table)
+
+        self.search = QLineEdit(placeholderText="Busca en enunciado u opciones…")
+        self.search.setEnabled(False)
+        self.search.textChanged.connect(self._filter_table)
+
+        btn_new = QPushButton("Nueva pregunta", clicked=self._new_question)
+
+        top = QHBoxLayout()
+        top.addWidget(self.cb_subject)
+        top.addWidget(self.search)
+        top.addStretch(1)
+        top.addWidget(btn_new)
+
+        # --- tabla ---
+        headers = [
+            "No.",
+            "Pregunta",
+            "Opciones de respuesta",
+            "Correcta",
+            "Explicación",
+            "",
+        ]
+        self.table = QTableWidget(0, len(headers))
+        self.table.setHorizontalHeaderLabels(headers)
+        self.table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        self.table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
+        self.table.horizontalHeader().setSectionResizeMode(3, QHeaderView.Stretch)
+        self.table.horizontalHeader().setSectionResizeMode(4, QHeaderView.Stretch)
+        self.table.verticalHeader().setVisible(False)
+        self.table.setWordWrap(True)
+
+        root = QVBoxLayout(self)
+        root.addLayout(top)
+        root.addWidget(self.table)
+
+        self._load_subjects()
+
+    # ---------------- loaders ----------------
+    def _load_subjects(self) -> None:
+        with SessionLocal() as s:
+            subs = s.query(m.Subject).order_by(m.Subject.name).all()
+        self.cb_subject.clear()
+        self.cb_subject.addItem("--- Selecciona materia ---", None)
+        for sub in subs:
+            self.cb_subject.addItem(sub.name, sub.id)
+
+    def _load_table(self) -> None:
+        subj_id = self.cb_subject.currentData()
+        self.search.setEnabled(bool(subj_id))
+        if not subj_id:
+            self.table.setRowCount(0)
+            return
+
+        query_text = self.search.text().strip().lower()
+        with SessionLocal() as s:
+            q = (
+                s.query(m.MCQQuestion)
+                .filter(m.MCQQuestion.subject_id == subj_id)
+                .order_by(m.MCQQuestion.id)
+            )
+            rows = q.all()
+
+        if query_text:
+            rows = [
+                r
+                for r in rows
+                if query_text in r.prompt.lower()
+                or any(query_text in o.text.lower() for o in r.options)
+            ]
+
+        self._populate_table(rows)
+
+    def _populate_table(self, rows: list[m.MCQQuestion]) -> None:
+        self.table.setRowCount(len(rows))
+        for i, q in enumerate(rows, start=1):
+            nitem = QTableWidgetItem(str(i))
+            nitem.setFlags(Qt.ItemIsEnabled)
+            nitem.setTextAlignment(Qt.AlignCenter)
+            self.table.setItem(i - 1, 0, nitem)
+
+            pitem = QTableWidgetItem(q.prompt)
+            pitem.setFlags(Qt.ItemIsEnabled)
+            self.table.setItem(i - 1, 1, pitem)
+
+            opts_txt = "\n".join(
+                f"{chr(97 + j)}) {o.text}" for j, o in enumerate(q.options)
+            )
+            corr_txt = "\n".join(o.text for o in q.options if o.is_correct)
+            expl_txt = "\n".join(o.explanation or "" for o in q.options)
+            for col, txt in zip((2, 3, 4), (opts_txt, corr_txt, expl_txt)):
+                item = QTableWidgetItem(txt)
+                item.setFlags(Qt.ItemIsEnabled)
+                self.table.setItem(i - 1, col, item)
+
+            btn_del = QPushButton("🗑️")
+            btn_del.setFlat(True)
+            btn_del.clicked.connect(lambda _, qid=q.id: self._delete_question(qid))
+            self.table.setCellWidget(i - 1, 5, btn_del)
+
+        self.table.resizeRowsToContents()
+
+    def _filter_table(self, _text: str) -> None:
+        self._load_table()
+
+    # ---------------- actions ----------------
+    def _new_question(self) -> None:
+        dlg = QuestionDialog(self)
+        if dlg.exec() == dlg.Accepted:
+            self._load_table()
+
+    def _delete_question(self, qid: int) -> None:
+        if (
+            QMessageBox.question(
+                self,
+                "Eliminar pregunta",
+                "¿Seguro que deseas borrar esta pregunta?",
+                QMessageBox.Yes | QMessageBox.No,
+            )
+            != QMessageBox.Yes
+        ):
+            return
+        with SessionLocal() as s:
+            s.query(m.MCQQuestion).filter_by(id=qid).delete()
+            s.commit()
+        self._load_table()


### PR DESCRIPTION
## Summary
- add `QuestionsWindow` with filtering and CRUD
- hook new window into main menu
- update menu docs and remove old action

## Testing
- `black examgen/gui/questions_window.py examgen/gui/main.py`
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844ad7e418c832985f9a847bb33dfbe