### PR TITLE
Add margin in QuestionsWindow

### DIFF
--- a/examgen/gui/questions_window.py
+++ b/examgen/gui/questions_window.py
@@ -68,7 +68,8 @@ class QuestionsWindow(QWidget):
         self.table.setWordWrap(True)
 
         root = QVBoxLayout(self)
-        root.setContentsMargins(0, 0, 0, 0)
+        # Margen izq, sup, der, inf  →  4 px de respiro arriba
+        root.setContentsMargins(4, 6, 4, 0)
         root.setSpacing(4)
         root.addLayout(top)
         root.addWidget(self.table)


### PR DESCRIPTION
## Summary
- add 6px top margin for QuestionsWindow layout so filters aren't flush with the title bar

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6844b4003cd083299fe1bac2561b1548