### PR TITLE
Style trash icon in questions table

### DIFF
--- a/examgen/gui/questions_window.py
+++ b/examgen/gui/questions_window.py
@@ -147,6 +147,20 @@ class QuestionsWindow(QWidget):
 
             btn_del = QPushButton("🗑️")
             btn_del.setFlat(True)
+            btn_del.setCursor(Qt.PointingHandCursor)
+            btn_del.setStyleSheet(
+                """
+                QPushButton {
+                    background: transparent;
+                    border: none;
+                    color: #ff6b6b;
+                    font-size: 16px;
+                }
+                QPushButton:hover {
+                    color: #ffa0a0;
+                }
+            """
+            )
             btn_del.clicked.connect(lambda _, qid=q.id: self._delete_question(qid))
             self.table.setCellWidget(cur_row, 5, btn_del)
             if n_opts > 1:


### PR DESCRIPTION
## Summary
- style deletion button in questions table with red trash icon

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844cf40986483299f8ca2f3aefb4bd9