### PR TITLE
Implement Questions window as separate dialog

### DIFF
--- a/examgen/gui/main.py
+++ b/examgen/gui/main.py
@@ -178,11 +178,8 @@ class MainWindow(QMainWindow):
     def _show_questions(self) -> None:
         from examgen.gui.questions_window import QuestionsWindow
 
-        if not hasattr(self, "_questions_win") or self._questions_win is None:
-            self._questions_win = QuestionsWindow(self)
-        self._questions_win.show()
-        self._questions_win.raise_()
-        self._questions_win.activateWindow()
+        win = QuestionsWindow()
+        win.show()
 
     def _show_history(self) -> None:
         from examgen.gui.dialogs import AttemptsHistoryDialog

--- a/examgen/gui/questions_window.py
+++ b/examgen/gui/questions_window.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from PySide6.QtWidgets import (
+    QDialog,
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
@@ -23,12 +24,12 @@ from examgen.gui.dialogs import QuestionDialog
 from sqlalchemy.orm import selectinload
 
 
-class QuestionsWindow(QWidget):
+class QuestionsWindow(QDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
-        super().__init__(parent)
+        super().__init__(parent=None)
         self.setWindowTitle("Preguntas")
-        if parent is not None:
-            self.resize(parent.size())
+        self.resize(1100, 700)
+        self.setAttribute(Qt.WA_DeleteOnClose)
 
         # --- fila 1: filtros + botón ---
         self.cb_subject = QComboBox()
@@ -193,15 +194,14 @@ class QuestionsWindow(QWidget):
             self._refresh_stats()
 
     def _delete_question(self, qid: int) -> None:
-        if (
-            QMessageBox.question(
-                self,
-                "Eliminar pregunta",
-                "¿Seguro que deseas borrar esta pregunta?",
-                QMessageBox.Yes | QMessageBox.No,
-            )
-            != QMessageBox.Yes
-        ):
+        reply = QMessageBox.question(
+            self,
+            "Eliminar pregunta",
+            "¿Seguro que deseas borrar esta pregunta?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
             return
         with SessionLocal() as s:
             s.query(m.MCQQuestion).filter_by(id=qid).delete()


### PR DESCRIPTION
## Summary
- confirm question deletion with QMessageBox defaulting to *No*
- display Questions window in a standalone dialog

## Testing
- `python -m py_compile examgen/gui/main.py examgen/gui/questions_window.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6844d077bc34832985519d61dbd38cae