### PR TITLE
Enable console entry for GUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "examgen"
 version = "0.1.0"
 
+[project.scripts]
+examgen = "examgen.gui.app:main"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/src/examgen/__main__.py
+++ b/src/examgen/__main__.py
@@ -1,3 +1,5 @@
+"""Permite ejecutar `python -m examgen`."""
+
 from examgen.gui.app import main
 
 if __name__ == "__main__":

--- a/src/examgen/gui/__init__.py
+++ b/src/examgen/gui/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
+"""UI package."""
 
-from .widgets.option_table import ExamDialog, start_exam
-
-__all__ = ["ExamDialog", "start_exam"]
+__all__: list[str] = []

--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -4,11 +4,13 @@ import sys
 
 from PySide6.QtWidgets import QApplication
 
-from examgen.gui.windows.main_window import MainWindow
-
 
 def main() -> None:
-    app = QApplication(sys.argv)
+    """Punto de entrada principal de la GUI."""
+    # Importar dentro de la función para evitar ciclos
+    from examgen.gui.windows.main_window import MainWindow
+
+    app = QApplication.instance() or QApplication(sys.argv)
     win = MainWindow()
     win.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- let GUI app import MainWindow lazily and reuse QApplication
- provide `__main__` alias for `python -m examgen`
- expose `examgen` console script via pyproject
- keep gui package init empty

## Testing
- `pip install -e .`
- `python -m examgen` *(fails: libEGL.so.1 missing)*
- `python -m examgen.gui.app` *(fails: libEGL.so.1 missing)*
- `examgen` *(fails: libEGL.so.1 missing)*
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68458d4d0f3883298cd2298ffb60c520