### PR TITLE
Persist theme settings

### DIFF
--- a/src/examgen/core/settings.py
+++ b/src/examgen/core/settings.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+import json
+import sys
+from pathlib import Path
+
+SETTINGS_PATH = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent.parent)) / "settings.json"
+
+@dataclass
+class AppSettings:
+    theme: str = "dark"
+
+    @classmethod
+    def load(cls) -> "AppSettings":
+        if SETTINGS_PATH.exists():
+            with SETTINGS_PATH.open("r", encoding="utf-8") as f:
+                return cls(**json.load(f))
+        return cls()
+
+    def save(self) -> None:
+        with SETTINGS_PATH.open("w", encoding="utf-8") as f:
+            json.dump(asdict(self), f, indent=2)


### PR DESCRIPTION
## Summary
- add `AppSettings` dataclass with JSON persistence
- refactor `MainWindow` to use settings
- split menu into **Configuración** and **Aplicación**
- add placeholder for theme toggling

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*
- `PYTHONPATH=src python -m examgen` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68459bc35c18832990d2a2a73286d3a9