### PR TITLE
Add database file chooser and menu lock

### DIFF
--- a/src/examgen/core/settings.py
+++ b/src/examgen/core/settings.py
@@ -5,18 +5,24 @@ import json
 import sys
 from pathlib import Path
 
-SETTINGS_PATH = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent.parent)) / "settings.json"
+SETTINGS_PATH = (
+    Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent.parent))
+    / "settings.json"
+)
+
 
 @dataclass
 class AppSettings:
     theme: str = "dark"
-    data_dir: str | None = None
+    data_db_path: str | None = None
 
     @classmethod
     def load(cls) -> "AppSettings":
         if SETTINGS_PATH.exists():
             with SETTINGS_PATH.open("r", encoding="utf-8") as f:
-                return cls(**json.load(f))
+                data = json.load(f)
+            allowed = {k: data[k] for k in ("theme", "data_db_path") if k in data}
+            return cls(**allowed)
         return cls()
 
     def save(self) -> None:

--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -11,10 +11,9 @@ from examgen.core.settings import AppSettings
 
 
 st = AppSettings.load()
-data_root = Path(st.data_dir or ".")
-data_root.mkdir(parents=True, exist_ok=True)
-DB_PATH = data_root / "examgen.db"
-engine = get_engine(DB_PATH)
+db_path = Path(st.data_db_path or Path.home() / "Documents" / "examgen.db")
+db_path.parent.mkdir(parents=True, exist_ok=True)
+engine = get_engine(db_path)
 init_db(engine)
 
 


### PR DESCRIPTION
## Summary
- allow specifying database file path in settings
- load settings.data_db_path to configure engine
- disable Application menu until a DB is selected
- warn user if they open disabled menu

## Testing
- `pytest -q` *(fails: libEGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a9a424f48329aff87c14f212bbee