### PR TITLE
Implement settings dialog

### DIFF
--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -14,7 +14,8 @@ st = AppSettings.load()
 db_path = Path(st.data_db_path or Path.home() / "Documents" / "examgen.db")
 db_path.parent.mkdir(parents=True, exist_ok=True)
 engine = get_engine(db_path)
-init_db(engine)
+if db_path.exists() or st.data_db_path is None:
+    init_db(engine)
 
 
 def main() -> None:

--- a/src/examgen/gui/dialogs/settings_dialog.py
+++ b/src/examgen/gui/dialogs/settings_dialog.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QStandardPaths
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from examgen.core.settings import AppSettings
+
+
+class SettingsDialog(QDialog):
+    """Dialog to edit application settings."""
+
+    def __init__(self, settings: AppSettings, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Configuración")
+        self.settings = settings
+
+        # --- Campo Tema ---
+        self.cb_theme = QComboBox()
+        self.cb_theme.addItems(["dark", "light"])
+        self.cb_theme.setCurrentText(settings.theme)
+
+        # --- Campo BD ---
+        self.le_db = QLineEdit(settings.data_db_path or "")
+        self.le_db.setReadOnly(True)
+        btn_choose = QPushButton("Elegir…", clicked=self._choose_db)
+
+        form = QFormLayout()
+        form.addRow("Tema:", self.cb_theme)
+        hb = QHBoxLayout()
+        hb.addWidget(self.le_db)
+        hb.addWidget(btn_choose)
+        form.addRow("Base de datos:", hb)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        root = QVBoxLayout(self)
+        root.addLayout(form)
+        root.addWidget(buttons)
+
+    def _choose_db(self) -> None:
+        start_dir = (
+            Path(self.settings.data_db_path).parent
+            if self.settings.data_db_path
+            else Path(QStandardPaths.writableLocation(QStandardPaths.DocumentsLocation))
+        )
+        path = QFileDialog.getExistingDirectory(
+            self,
+            "Seleccionar carpeta de datos",
+            str(start_dir),
+        )
+        if not path:
+            return
+        self.le_db.setText(str(Path(path) / "examgen.db"))
+
+    def accept(self) -> None:  # type: ignore[override]
+        self.settings.theme = self.cb_theme.currentText()
+        self.settings.data_db_path = self.le_db.text() or None
+        self.settings.save()
+        super().accept()
+


### PR DESCRIPTION
## Summary
- rename Configuración menu to Archivo
- add dialog to configure theme and DB path
- update application DB initialization logic
- adjust warning message when DB missing

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845af43d910832988d44d89a7bf9aec