### PR TITLE
Enable dynamic DB switching

### DIFF
--- a/src/examgen/core/database.py
+++ b/src/examgen/core/database.py
@@ -6,14 +6,50 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
-from examgen.core.models import Base
+from examgen.core.models import Base, _create_examiner_tables
 
 
-def get_engine(db_path: Path) -> Engine:
-    """Return a SQLite engine for the given database path."""
-    return create_engine(f"sqlite:///{db_path}", echo=False, future=True)
+_engine: Engine | None = None
+SessionLocal = sessionmaker(expire_on_commit=False, future=True)
+
+
+def set_engine(db_path: Path) -> None:
+    """Create and register a new engine bound to ``db_path``."""
+    global _engine
+    _engine = create_engine(f"sqlite:///{db_path}", echo=False, future=True)
+    SessionLocal.configure(bind=_engine)
+    if db_path.exists():
+        init_db(_engine)
+
+
+def get_engine() -> Engine:
+    """Return the currently configured engine."""
+    if _engine is None:
+        raise RuntimeError("Engine not initialised. Call set_engine() first")
+    return _engine
 
 
 def init_db(engine: Engine) -> None:
-    """Create all tables if they do not exist."""
+    """Create tables and apply idempotent migrations."""
     Base.metadata.create_all(engine)
+
+    _create_examiner_tables(engine)
+
+    with engine.begin() as con:
+        con.exec_driver_sql("PRAGMA foreign_keys = ON")
+
+        existing_cols = {
+            tbl: {row[1] for row in con.exec_driver_sql(f"PRAGMA table_info({tbl})")}
+            for tbl in ("question", "answer_option")
+        }
+
+        if (
+            "reference" not in existing_cols["question"]
+            and "reference_id" not in existing_cols["question"]
+        ):
+            con.exec_driver_sql("ALTER TABLE question ADD COLUMN reference TEXT")
+
+        for col_sql in ("answer TEXT", "explanation TEXT"):
+            col_name = col_sql.split()[0]
+            if col_name not in existing_cols["answer_option"]:
+                con.exec_driver_sql(f"ALTER TABLE answer_option ADD COLUMN {col_sql}")

--- a/src/examgen/core/services/exam_service.py
+++ b/src/examgen/core/services/exam_service.py
@@ -9,16 +9,7 @@ from sqlalchemy import select, func
 from sqlalchemy.orm import Session, selectinload, with_polymorphic
 
 from examgen.core import models as m
-
-from examgen.core.models import (
-    SessionLocal,
-    Attempt,
-    AttemptQuestion,
-    Question,
-    ExamQuestion,
-    SelectorTypeEnum,
-    Subject,
-)
+from examgen.core.database import SessionLocal
 
 
 @dataclass(slots=True)
@@ -26,7 +17,7 @@ class ExamConfig:
     exam_id: int
     subject: str
     subject_id: int
-    selector_type: SelectorTypeEnum
+    selector_type: m.SelectorTypeEnum
     num_questions: int | None
     error_threshold: int | None
     time_limit: int
@@ -34,28 +25,28 @@ class ExamConfig:
 
 def _select_random(
     session: Session, exam_id: int, limit: int, subject_id: int | None = None
-) -> List[Question]:
+) -> List[m.Question]:
     attempts_sub = (
         select(
-            AttemptQuestion.question_id,
-            func.count(AttemptQuestion.id).label("attempts_count"),
+            m.AttemptQuestion.question_id,
+            func.count(m.AttemptQuestion.id).label("attempts_count"),
         )
-        .group_by(AttemptQuestion.question_id)
+        .group_by(m.AttemptQuestion.question_id)
         .subquery()
     )
     stmt = (
-        select(Question)
-        .join(ExamQuestion, ExamQuestion.question_id == Question.id)
-        .outerjoin(attempts_sub, attempts_sub.c.question_id == Question.id)
-        .filter(ExamQuestion.exam_id == exam_id)
+        select(m.Question)
+        .join(m.ExamQuestion, m.ExamQuestion.question_id == m.Question.id)
+        .outerjoin(attempts_sub, attempts_sub.c.question_id == m.Question.id)
+        .filter(m.ExamQuestion.exam_id == exam_id)
         .order_by(func.coalesce(attempts_sub.c.attempts_count, 0).asc(), func.random())
         .limit(limit)
     )
     questions = list(session.scalars(stmt))
     if not questions and subject_id is not None:
         questions = (
-            session.query(Question)
-            .filter(Question.subject_id == subject_id)
+            session.query(m.Question)
+            .filter(m.Question.subject_id == subject_id)
             .order_by(func.random())
             .limit(limit)
             .all()
@@ -65,34 +56,34 @@ def _select_random(
 
 def _select_by_errors(
     session: Session, exam_id: int, limit: int, subject_id: int | None = None
-) -> List[Question]:
+) -> List[m.Question]:
     error_sub = (
         select(
-            AttemptQuestion.question_id,
-            func.count(AttemptQuestion.id).label("errors_count"),
+            m.AttemptQuestion.question_id,
+            func.count(m.AttemptQuestion.id).label("errors_count"),
         )
-        .where(AttemptQuestion.is_correct.is_(False))
-        .group_by(AttemptQuestion.question_id)
+        .where(m.AttemptQuestion.is_correct.is_(False))
+        .group_by(m.AttemptQuestion.question_id)
         .subquery()
     )
     attempts_sub = (
         select(
-            AttemptQuestion.question_id,
-            func.count(AttemptQuestion.id).label("attempts_count"),
+            m.AttemptQuestion.question_id,
+            func.count(m.AttemptQuestion.id).label("attempts_count"),
         )
-        .group_by(AttemptQuestion.question_id)
+        .group_by(m.AttemptQuestion.question_id)
         .subquery()
     )
     stmt = (
         select(
-            Question,
+            m.Question,
             func.coalesce(error_sub.c.errors_count, 0).label("errors"),
             func.coalesce(attempts_sub.c.attempts_count, 0).label("attempts"),
         )
-        .join(ExamQuestion, ExamQuestion.question_id == Question.id)
-        .outerjoin(error_sub, error_sub.c.question_id == Question.id)
-        .outerjoin(attempts_sub, attempts_sub.c.question_id == Question.id)
-        .filter(ExamQuestion.exam_id == exam_id)
+        .join(m.ExamQuestion, m.ExamQuestion.question_id == m.Question.id)
+        .outerjoin(error_sub, error_sub.c.question_id == m.Question.id)
+        .outerjoin(attempts_sub, attempts_sub.c.question_id == m.Question.id)
+        .filter(m.ExamQuestion.exam_id == exam_id)
         .order_by(
             func.coalesce(error_sub.c.errors_count, 0).desc(),
             func.coalesce(attempts_sub.c.attempts_count, 0).asc(),
@@ -105,27 +96,28 @@ def _select_by_errors(
     return [row.Question for row in results]
 
 
-def create_attempt(config: ExamConfig) -> Attempt:
+def create_attempt(config: ExamConfig) -> m.Attempt:
     """Persist a new Attempt with its questions."""
     with SessionLocal() as session:
         if config.exam_id == 0:
             stmt = (
-                session.query(Question)
-                .join(Subject, Question.subject_id == Subject.id)
-                .filter(func.lower(Subject.name) == config.subject.lower())
+                session.query(m.Question)
+                .join(m.Subject, m.Question.subject_id == m.Subject.id)
+                .filter(func.lower(m.Subject.name) == config.subject.lower())
                 .order_by(func.random())
                 .limit(config.num_questions or 0)
             )
             questions = stmt.all()
             random.shuffle(questions)
             if not questions:
-                raise ValueError(
-                    f'No hay preguntas para la materia "{config.subject}"'
-                )
+                raise ValueError(f'No hay preguntas para la materia "{config.subject}"')
         else:
-            if config.selector_type is SelectorTypeEnum.ALEATORIO:
+            if config.selector_type is m.SelectorTypeEnum.ALEATORIO:
                 questions = _select_random(
-                    session, config.exam_id, config.num_questions or 0, config.subject_id
+                    session,
+                    config.exam_id,
+                    config.num_questions or 0,
+                    config.subject_id,
                 )
             else:
                 threshold = config.error_threshold or 0
@@ -136,9 +128,9 @@ def create_attempt(config: ExamConfig) -> Attempt:
 
             if not questions:
                 questions = (
-                    session.query(Question)
-                    .join(Subject, Question.subject_id == Subject.id)
-                    .filter(func.lower(Subject.name) == config.subject.lower())
+                    session.query(m.Question)
+                    .join(m.Subject, m.Question.subject_id == m.Subject.id)
+                    .filter(func.lower(m.Subject.name) == config.subject.lower())
                     .order_by(func.random())
                     .limit(config.num_questions or 0)
                     .all()
@@ -146,11 +138,9 @@ def create_attempt(config: ExamConfig) -> Attempt:
                 random.shuffle(questions)
 
             if not questions:
-                raise ValueError(
-                    f'No hay preguntas para la materia "{config.subject}"'
-                )
+                raise ValueError(f'No hay preguntas para la materia "{config.subject}"')
 
-        attempt = Attempt(
+        attempt = m.Attempt(
             exam_id=config.exam_id,
             subject=config.subject,
             selector_type=config.selector_type,
@@ -162,17 +152,17 @@ def create_attempt(config: ExamConfig) -> Attempt:
         session.add(attempt)
 
         for q in questions:
-            attempt.questions.append(AttemptQuestion(question=q))
+            attempt.questions.append(m.AttemptQuestion(question=q))
 
         session.commit()
 
         q_poly = with_polymorphic(m.Question, "*")
 
         attempt = (
-            session.query(Attempt)
+            session.query(m.Attempt)
             .options(
-                selectinload(Attempt.questions)
-                .selectinload(AttemptQuestion.question.of_type(q_poly))
+                selectinload(m.Attempt.questions)
+                .selectinload(m.AttemptQuestion.question.of_type(q_poly))
                 .selectinload(q_poly.MCQQuestion.options)
             )
             .filter_by(id=attempt.id)
@@ -183,7 +173,7 @@ def create_attempt(config: ExamConfig) -> Attempt:
         return attempt
 
 
-def _compute_score(attempt: Attempt) -> int:
+def _compute_score(attempt: m.Attempt) -> int:
     """Calculate score and update AttemptQuestion entries."""
     total = 0
     for aq in attempt.questions:
@@ -219,9 +209,7 @@ def evaluate_attempt(attempt_id: int) -> m.Attempt:
         correct = 0
         for aq in attempt.questions:
             q = aq.question
-            correct_set = {
-                l for l, opt in zip("ABCDE", q.options) if opt.is_correct
-            }
+            correct_set = {l for l, opt in zip("ABCDE", q.options) if opt.is_correct}
             if aq.selected_option:
                 if len(correct_set) == 1:
                     aq.is_correct = aq.selected_option in correct_set
@@ -246,7 +234,7 @@ if __name__ == "__main__":
         exam_id=1,
         subject="Demo",
         subject_id=1,
-        selector_type=SelectorTypeEnum.ALEATORIO,
+        selector_type=m.SelectorTypeEnum.ALEATORIO,
         num_questions=3,
         error_threshold=None,
         time_limit=10,

--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -6,16 +6,16 @@ from pathlib import Path
 
 from PySide6.QtWidgets import QApplication
 
-from examgen.core.database import get_engine, init_db
+from examgen.core.database import get_engine, init_db, set_engine
 from examgen.core.settings import AppSettings
 
 
 st = AppSettings.load()
 db_path = Path(st.data_db_path or Path.home() / "Documents" / "examgen.db")
 db_path.parent.mkdir(parents=True, exist_ok=True)
-engine = get_engine(db_path)
+set_engine(db_path)
 if db_path.exists() or st.data_db_path is None:
-    init_db(engine)
+    init_db(get_engine())
 
 
 def main() -> None:

--- a/src/examgen/gui/dialogs/history_dialog.py
+++ b/src/examgen/gui/dialogs/history_dialog.py
@@ -17,7 +17,7 @@ from PySide6.QtWidgets import (
 from sqlalchemy.orm import selectinload
 
 from examgen.core import models as m
-from examgen.core.models import SessionLocal
+from examgen.core.database import SessionLocal
 
 
 class AttemptsHistoryDialog(QDialog):
@@ -101,7 +101,9 @@ class AttemptsHistoryDialog(QDialog):
             w_cells = max(self.table.sizeHintForColumn(c), w_head)
             self.table.setColumnWidth(c, w_cells + 12)
 
-        total_w = sum(self.table.columnWidth(c) for c in range(self.table.columnCount()))
+        total_w = sum(
+            self.table.columnWidth(c) for c in range(self.table.columnCount())
+        )
         total_w += self.table.verticalHeader().width() + 40
         self.table.setMinimumWidth(total_w)
         self.resize(total_w, self.height())

--- a/src/examgen/gui/dialogs/results_dialog.py
+++ b/src/examgen/gui/dialogs/results_dialog.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from sqlalchemy.orm import selectinload, joinedload
 
 from examgen.core import models as m
-from examgen.core.models import SessionLocal
+from examgen.core.database import SessionLocal
 from examgen.core.services.exam_service import Attempt
 
 

--- a/src/examgen/gui/dialogs/settings_dialog.py
+++ b/src/examgen/gui/dialogs/settings_dialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 )
 
 from examgen.core.settings import AppSettings
+from examgen.core.database import set_engine
 
 
 class SettingsDialog(QDialog):
@@ -71,5 +72,6 @@ class SettingsDialog(QDialog):
         self.settings.theme = self.cb_theme.currentText()
         self.settings.data_db_path = self.le_db.text() or None
         self.settings.save()
+        if self.settings.data_db_path:
+            set_engine(Path(self.settings.data_db_path))
         super().accept()
-

--- a/src/examgen/gui/widgets/option_table.py
+++ b/src/examgen/gui/widgets/option_table.py
@@ -23,7 +23,8 @@ from PySide6.QtWidgets import (
     QAbstractButton,
 )
 
-from examgen.core.models import Attempt, AttemptQuestion, SessionLocal
+from examgen.core.models import Attempt, AttemptQuestion
+from examgen.core.database import SessionLocal
 from examgen.core.services.exam_service import (
     ExamConfig,
     create_attempt,
@@ -145,7 +146,6 @@ class ExamDialog(QDialog):
         opts_container = QWidget()
         self.vbox_opts = QVBoxLayout(opts_container)
         self.vbox_opts.setContentsMargins(0, 0, 0, 0)
-
 
         nav = QHBoxLayout()
         self.btn_prev = QPushButton("\u2190 Anterior", clicked=self._prev)
@@ -362,7 +362,6 @@ class ExamDialog(QDialog):
         if self.index == len(self.attempt.questions) - 1:
             self._next()
 
-
     def on_toggle_clicked(self) -> None:
         if not self.expl_shown:
             self._save_selection()
@@ -411,7 +410,8 @@ class ExamDialog(QDialog):
         self._save_selection()
         self.attempt.ended_at = datetime.utcnow()
 
-        from examgen.core.models import SessionLocal
+        from examgen.core.database import SessionLocal
+
         with SessionLocal() as s:
             s.merge(self.attempt)
             s.commit()

--- a/src/examgen/gui/windows/questions_window.py
+++ b/src/examgen/gui/windows/questions_window.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 
 from examgen.core import models as m
-from examgen.core.models import SessionLocal
+from examgen.core.database import SessionLocal
 from examgen.gui.dialogs.question_dialog import QuestionDialog
 from sqlalchemy.orm import selectinload
 
@@ -35,9 +35,7 @@ class QuestionsWindow(QDialog):
         self.cb_subject = QComboBox()
         self.cb_subject.currentIndexChanged.connect(self._load_table)
 
-        self.search = QLineEdit(
-            placeholderText="Busca en enunciado u opciones…"
-        )
+        self.search = QLineEdit(placeholderText="Busca en enunciado u opciones…")
         self.search.setEnabled(False)
         self.search.setMinimumWidth(400)
         self.search.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
@@ -169,7 +167,9 @@ class QuestionsWindow(QDialog):
 
             for rel_idx, opt in enumerate(q.options):
                 row = cur_row + rel_idx
-                self.table.setItem(row, 2, QTableWidgetItem(f"{chr(97 + rel_idx)}) {opt.text}"))
+                self.table.setItem(
+                    row, 2, QTableWidgetItem(f"{chr(97 + rel_idx)}) {opt.text}")
+                )
                 corr_txt = "✔" if opt.is_correct else ""
                 self.table.setItem(row, 3, QTableWidgetItem(corr_txt))
                 self.table.setItem(row, 4, QTableWidgetItem(opt.explanation or ""))


### PR DESCRIPTION
## Summary
- centralize SQLAlchemy engine in `core.database`
- set engine on app start and when saving settings
- update dialogs and services to use the new session

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6845b97169d08329980c0e4a0c3ec2ad