### PR TITLE
Fix Attempt import in ResultsDialog

### DIFF
--- a/src/examgen/gui/dialogs/results_dialog.py
+++ b/src/examgen/gui/dialogs/results_dialog.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
@@ -15,11 +14,11 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 
-from sqlalchemy.orm import selectinload, joinedload
+from sqlalchemy.orm import selectinload
 
 from examgen.core import models as m
 from examgen.core.database import SessionLocal
-from examgen.core.services.exam_service import Attempt
+from examgen.core.models import Attempt
 
 
 class ResultsDialog(QDialog):


### PR DESCRIPTION
## Summary
- use `Attempt` from `core.models` not from the service

## Testing
- `ruff check src/examgen/gui/dialogs/results_dialog.py`
- `black src/examgen/gui/dialogs/results_dialog.py --line-length 88`
- `pytest -q` *(fails: ImportError `libEGL.so.1`)*
- `PYTHONPATH=src python -m examgen --help` *(fails: ImportError `libEGL.so.1`)*

------
https://chatgpt.com/codex/tasks/task_e_6845c0fccb988329b5d6f8a93bb07707