### PR TITLE
Resolve FK constraint when exam is not selected

### DIFF
--- a/src/examgen/core/services/exam_service.py
+++ b/src/examgen/core/services/exam_service.py
@@ -141,7 +141,7 @@ def create_attempt(config: ExamConfig) -> m.Attempt:
                 raise ValueError(f'No hay preguntas para la materia "{config.subject}"')
 
         attempt = m.Attempt(
-            exam_id=config.exam_id,
+            exam_id=config.exam_id or None,
             subject=config.subject,
             selector_type=config.selector_type,
             num_questions=config.num_questions,


### PR DESCRIPTION
## Summary
- handle optional `exam_id` when creating attempts
- allow NULL `exam_id` in attempts and migrate existing DBs

## Testing
- `black --check src/examgen/core/models.py src/examgen/core/services/exam_service.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7e834b0832982ec680baaf15400