### PR TITLE
Fix attempt_question FK migration

### DIFF
--- a/src/examgen/core/database.py
+++ b/src/examgen/core/database.py
@@ -53,3 +53,9 @@ def init_db(engine: Engine) -> None:
             col_name = col_sql.split()[0]
             if col_name not in existing_cols["answer_option"]:
                 con.exec_driver_sql(f"ALTER TABLE answer_option ADD COLUMN {col_sql}")
+
+def run_migrations() -> None:
+    """Execute optional migration scripts."""
+    from examgen.core.migrations.fix_attempt_fk import run as fix_fk
+
+    fix_fk()

--- a/src/examgen/core/migrations/fix_attempt_fk.py
+++ b/src/examgen/core/migrations/fix_attempt_fk.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table, create_engine
+
+from examgen.core.settings import AppSettings
+
+
+def run() -> None:
+    """Fix attempt_question FK pointing to attempt.id."""
+    db_path = Path(AppSettings.load().data_db_path or Path.home() / "Documents" / "examgen.db")
+    eng = create_engine(f"sqlite:///{db_path}", future=True)
+    meta = MetaData(bind=eng)
+    meta.reflect()
+
+    if "attempt_question" not in meta.tables:
+        print("Tabla attempt_question no existe; nada que hacer.")
+        return
+
+    aq_old = meta.tables["attempt_question"]
+
+    bad_fk = next(
+        (fk for fk in aq_old.foreign_keys if fk.column.table.name == "attempt_old"),
+        None,
+    )
+    if not bad_fk:
+        print("FK ya es correcta; nada que hacer.")
+        return
+
+    with eng.begin() as conn:
+        print("Migrando FK de attempt_question ...")
+        conn.exec_driver_sql("ALTER TABLE attempt_question RENAME TO attempt_question_old;")
+
+        meta2 = MetaData()
+        Table(
+            "attempt_question",
+            meta2,
+            Column("id", Integer, primary_key=True),
+            Column(
+                "attempt_id",
+                Integer,
+                ForeignKey("attempt.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            Column(
+                "question_id",
+                Integer,
+                ForeignKey("question.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            Column("selected_option", String, nullable=True),
+            Column("is_correct", Integer, nullable=True),
+            Column("score", Integer, nullable=True),
+            Column("created_at", String),
+            Column("updated_at", String),
+        )
+        meta2.create_all(bind=conn)
+
+        conn.exec_driver_sql(
+            """
+            INSERT INTO attempt_question (id, attempt_id, question_id,
+                                          selected_option, is_correct, score,
+                                          created_at, updated_at)
+            SELECT id, attempt_id, question_id,
+                   selected_option, is_correct, score,
+                   created_at, updated_at
+            FROM attempt_question_old;
+            """
+        )
+
+        conn.exec_driver_sql("DROP TABLE attempt_question_old;")
+        print("Migración completada.")
+

--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from PySide6.QtWidgets import QApplication
 
-from examgen.core.database import get_engine, init_db, set_engine
+from examgen.core.database import get_engine, init_db, run_migrations, set_engine
 from examgen.core.settings import AppSettings
 
 
@@ -14,6 +14,7 @@ st = AppSettings.load()
 db_path = Path(st.data_db_path or Path.home() / "Documents" / "examgen.db")
 db_path.parent.mkdir(parents=True, exist_ok=True)
 set_engine(db_path)
+run_migrations()
 if db_path.exists() or st.data_db_path is None:
     init_db(get_engine())
 


### PR DESCRIPTION
## Summary
- fix AttemptQuestion FK referencing `attempt_old` via migration
- expose `run_migrations` utility and call on GUI startup

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845ce0ca6f483299633b62ca381755e