### PR TITLE
Fix MetaData usage in attempt FK migration

### DIFF
--- a/src/examgen/core/migrations/fix_attempt_fk.py
+++ b/src/examgen/core/migrations/fix_attempt_fk.py
@@ -11,11 +11,11 @@ def run() -> None:
     """Fix attempt_question FK pointing to attempt.id."""
     db_path = Path(AppSettings.load().data_db_path or Path.home() / "Documents" / "examgen.db")
     eng = create_engine(f"sqlite:///{db_path}", future=True)
-    meta = MetaData(bind=eng)
-    meta.reflect()
+    meta = MetaData()
+    meta.reflect(bind=eng)
 
     if "attempt_question" not in meta.tables:
-        print("Tabla attempt_question no existe; nada que hacer.")
+        print("Tabla 'attempt_question' no existe; nada que migrar.")
         return
 
     aq_old = meta.tables["attempt_question"]
@@ -55,7 +55,7 @@ def run() -> None:
             Column("created_at", String),
             Column("updated_at", String),
         )
-        meta2.create_all(bind=conn)
+        meta2.create_all(conn)
 
         conn.exec_driver_sql(
             """


### PR DESCRIPTION
## Summary
- adjust MetaData calls for SQLAlchemy 2.x

## Testing
- `ruff check .`
- `mypy src/examgen` *(fails: many missing stubs)*
- `pytest -q` *(fails: ImportError: libEGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_6845d19dcae88329a0616434e4f9c9a8