### PR TITLE
Add subtopic field to questions

### DIFF
--- a/src/examgen/core/database.py
+++ b/src/examgen/core/database.py
@@ -54,8 +54,11 @@ def init_db(engine: Engine) -> None:
             if col_name not in existing_cols["answer_option"]:
                 con.exec_driver_sql(f"ALTER TABLE answer_option ADD COLUMN {col_sql}")
 
+
 def run_migrations() -> None:
     """Execute optional migration scripts."""
     from examgen.core.migrations.fix_attempt_fk import run as fix_fk
+    from examgen.core.migrations.add_section import run as add_section
 
     fix_fk()
+    add_section()

--- a/src/examgen/core/migrations/add_section.py
+++ b/src/examgen/core/migrations/add_section.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+from sqlalchemy import create_engine
+
+from examgen.core.settings import AppSettings
+
+
+def run() -> None:
+    """Ensure ``section`` column exists in ``question`` table."""
+    db_path = Path(
+        AppSettings.load().data_db_path or Path.home() / "Documents" / "examgen.db"
+    )
+    eng = create_engine(f"sqlite:///{db_path}", future=True)
+    with eng.begin() as conn:
+        cols = {row[1] for row in conn.exec_driver_sql("PRAGMA table_info('question')")}
+        if "section" not in cols:
+            conn.exec_driver_sql(
+                "ALTER TABLE question ADD COLUMN section VARCHAR(255);"
+            )

--- a/src/examgen/gui/dialogs/question_dialog.py
+++ b/src/examgen/gui/dialogs/question_dialog.py
@@ -301,12 +301,16 @@ class QuestionDialog(QDialog):
         self.resize(1920, 1080)
 
         self.cb_subject = QComboBox(editable=True, fixedWidth=500)
+        self.le_section = QLineEdit(maxLength=255)
         self.le_reference = QLineEdit()
         self.le_reference.setPlaceholderText("ej.: exam_1025")
 
         top = QHBoxLayout()
         top.setContentsMargins(0, 0, 0, 0)
         top.addWidget(self.cb_subject)
+        top.addSpacing(20)
+        top.addWidget(QLabel("Sección:"))
+        top.addWidget(self.le_section)
         top.addSpacing(20)
         top.addWidget(QLabel("Referencia:"))
         top.addWidget(self.le_reference)
@@ -362,6 +366,7 @@ class QuestionDialog(QDialog):
     def accept(self) -> None:  # type: ignore[override]
         subj = self.cb_subject.currentText().strip()
         ref = self.le_reference.text().strip()
+        section = self.le_section.text().strip()
         prompt_txt = self.prompt.toPlainText().strip()
 
         if not subj or not prompt_txt:
@@ -388,7 +393,10 @@ class QuestionDialog(QDialog):
             )
 
             q = m.MCQQuestion(
-                prompt=prompt_txt, subject=subj_obj, reference=ref or None
+                prompt=prompt_txt,
+                subject=subj_obj,
+                reference=ref or None,
+                section=section or None,
             )
             q.options = options
             s.add(q)

--- a/src/examgen/gui/windows/questions_window.py
+++ b/src/examgen/gui/windows/questions_window.py
@@ -52,7 +52,9 @@ class QuestionsWindow(QDialog):
         # --- tabla ---
         headers = [
             "No.",
+            "Referencia",
             "Pregunta",
+            "Sección",
             "Opciones de respuesta",
             "Correcta",
             "Explicación",
@@ -60,10 +62,8 @@ class QuestionsWindow(QDialog):
         ]
         self.table = QTableWidget(0, len(headers))
         self.table.setHorizontalHeaderLabels(headers)
-        self.table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
-        self.table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
-        self.table.horizontalHeader().setSectionResizeMode(3, QHeaderView.Stretch)
-        self.table.horizontalHeader().setSectionResizeMode(4, QHeaderView.Stretch)
+        for idx in range(2, 7):
+            self.table.horizontalHeader().setSectionResizeMode(idx, QHeaderView.Stretch)
         self.table.verticalHeader().setVisible(False)
         self.table.setWordWrap(True)
         self.table.setShowGrid(True)
@@ -138,11 +138,23 @@ class QuestionsWindow(QDialog):
             if n_opts > 1:
                 self.table.setSpan(cur_row, 0, n_opts, 1)
 
-            pitem = QTableWidgetItem(q.prompt)
-            pitem.setFlags(Qt.ItemIsEnabled)
-            self.table.setItem(cur_row, 1, pitem)
+            ref_item = QTableWidgetItem(q.reference or "")
+            ref_item.setFlags(Qt.ItemIsEnabled)
+            self.table.setItem(cur_row, 1, ref_item)
             if n_opts > 1:
                 self.table.setSpan(cur_row, 1, n_opts, 1)
+
+            pitem = QTableWidgetItem(q.prompt)
+            pitem.setFlags(Qt.ItemIsEnabled)
+            self.table.setItem(cur_row, 2, pitem)
+            if n_opts > 1:
+                self.table.setSpan(cur_row, 2, n_opts, 1)
+
+            section_item = QTableWidgetItem(q.section or "")
+            section_item.setFlags(Qt.ItemIsEnabled)
+            self.table.setItem(cur_row, 3, section_item)
+            if n_opts > 1:
+                self.table.setSpan(cur_row, 3, n_opts, 1)
 
             btn_del = QPushButton("🗑️")
             btn_del.setFlat(True)
@@ -161,18 +173,18 @@ class QuestionsWindow(QDialog):
             """
             )
             btn_del.clicked.connect(lambda _, qid=q.id: self._delete_question(qid))
-            self.table.setCellWidget(cur_row, 5, btn_del)
+            self.table.setCellWidget(cur_row, 7, btn_del)
             if n_opts > 1:
-                self.table.setSpan(cur_row, 5, n_opts, 1)
+                self.table.setSpan(cur_row, 7, n_opts, 1)
 
             for rel_idx, opt in enumerate(q.options):
                 row = cur_row + rel_idx
                 self.table.setItem(
-                    row, 2, QTableWidgetItem(f"{chr(97 + rel_idx)}) {opt.text}")
+                    row, 4, QTableWidgetItem(f"{chr(97 + rel_idx)}) {opt.text}")
                 )
                 corr_txt = "✔" if opt.is_correct else ""
-                self.table.setItem(row, 3, QTableWidgetItem(corr_txt))
-                self.table.setItem(row, 4, QTableWidgetItem(opt.explanation or ""))
+                self.table.setItem(row, 5, QTableWidgetItem(corr_txt))
+                self.table.setItem(row, 6, QTableWidgetItem(opt.explanation or ""))
 
             cur_row += n_opts
         self.table.resizeRowsToContents()


### PR DESCRIPTION
## Summary
- add `section` column to Question model
- create migration and migrate on start
- expose section input in question dialog
- show section in Questions window

## Testing
- `ruff check src/examgen/core/database.py src/examgen/core/migrations/add_section.py src/examgen/core/models.py src/examgen/gui/dialogs/question_dialog.py src/examgen/gui/windows/questions_window.py --quiet`
- `black src/examgen/core/database.py src/examgen/core/migrations/add_section.py src/examgen/core/models.py src/examgen/gui/dialogs/question_dialog.py src/examgen/gui/windows/questions_window.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68468ab7749083298676ff2e9e88052a