### PR TITLE
Fix MCQ dialog validation

### DIFF
--- a/src/examgen/gui/dialogs/question_dialog.py
+++ b/src/examgen/gui/dialogs/question_dialog.py
@@ -396,11 +396,11 @@ class QuestionDialog(QDialog):
             return
 
         options, correct = self.table.collect()
-        if len(options) < 2 or correct == 0:
+        if len(options) < 3 or correct == 0:
             QMessageBox.warning(
                 self,
                 "Datos incompletos",
-                "Añade ≥2 opciones y marca la(s) correcta(s).",
+                "Añade ≥3 opciones y marca la(s) correcta(s).",
             )
             return
 


### PR DESCRIPTION
## Summary
- require at least three answer options in the 'Nueva pregunta – MCQ' dialog

## Testing
- `ruff check src/examgen/gui/dialogs/question_dialog.py`
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7f54fec8329a21631b0fd7ecfe4