### PR TITLE
Fix SessionLocal usage in QuestionDialog

### DIFF
--- a/src/examgen/gui/dialogs/question_dialog.py
+++ b/src/examgen/gui/dialogs/question_dialog.py
@@ -404,10 +404,7 @@ class QuestionDialog(QDialog):
             )
             return
 
-        from examgen.core.database import get_engine
-
-        engine = get_engine()
-        with m.Session(engine) as s:
+        with SessionLocal() as s:
             subj_obj = s.query(m.Subject).filter_by(name=subj).first() or m.Subject(
                 name=subj
             )


### PR DESCRIPTION
## Summary
- use `SessionLocal` when saving questions

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed78e1488329afab23d03b963fba