### PR TITLE
Fix OptionTable row removal

### DIFF
--- a/src/examgen/gui/dialogs/question_dialog.py
+++ b/src/examgen/gui/dialogs/question_dialog.py
@@ -116,8 +116,15 @@ class OptionTable(QTableWidget):
         trash = QToolButton()
         trash.setIcon(QIcon.fromTheme("edit-delete"))
         trash.setAutoRaise(True)
-        trash.clicked.connect(lambda *_: self._remove_row(row))
+        trash.clicked.connect(self._remove_clicked)
         self.setCellWidget(row, 4, trash)
+
+    def _remove_clicked(self) -> None:
+        """Slot conectado a cada papelera; elimina la fila donde vive el botón."""
+        btn: QToolButton = self.sender()  # type: ignore
+        if btn:
+            r = self.indexAt(btn.parent().pos()).row()
+            self._remove_row(r)
 
     def add_row(self) -> None:
         r = self.rowCount()


### PR DESCRIPTION
## Summary
- fix row removal in OptionTable by determining the row at click time

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6846f5a577e48329beeac336be2a5430