### PR TITLE
Robust row detection for OptionTable

### DIFF
--- a/src/examgen/gui/dialogs/question_dialog.py
+++ b/src/examgen/gui/dialogs/question_dialog.py
@@ -120,16 +120,17 @@ class OptionTable(QTableWidget):
         self.setCellWidget(row, 4, trash)
 
     def _remove_clicked(self) -> None:
-        """Eliminar la fila donde vive el botón papelera que emitió la señal."""
+        """Eliminar la fila que contiene el botón papelera que emitió la señal."""
         btn = self.sender()
         if not isinstance(btn, QToolButton):
             return
-
-        for row in range(self.rowCount()):
-            cell = self.cellWidget(row, 4)
-            if cell is btn or (cell and cell.findChild(QToolButton) is btn):
-                self._remove_row(row)
-                break
+        cell_widget = btn.parent()
+        if not cell_widget:
+            return
+        index = self.indexAt(cell_widget.pos())
+        row = index.row()
+        if row >= 0:
+            self._remove_row(row)
 
     def add_row(self) -> None:
         r = self.rowCount()


### PR DESCRIPTION
## Summary
- keep track of row to delete by asking the table for the cell index

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6847079416ec8329b11139f53fb07606