### PR TITLE
Determine row from trash button

### DIFF
--- a/src/examgen/gui/dialogs/question_dialog.py
+++ b/src/examgen/gui/dialogs/question_dialog.py
@@ -125,11 +125,7 @@ class OptionTable(QTableWidget):
         if not isinstance(btn, QToolButton):
             return
 
-        cell_widget = btn.parent()
-        if not cell_widget:
-            return
-
-        pos_in_view = cell_widget.mapTo(self.viewport(), QPoint(0, 0))
+        pos_in_view = btn.mapTo(self.viewport(), QPoint(0, 0))
         index = self.indexAt(pos_in_view)
         if index.isValid():
             self._remove_row(index.row())


### PR DESCRIPTION
## Summary
- fix OptionTable row removal by mapping the clicked button to the viewport

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68470c6f4d288329b2e2b7d3fa69c350