### PR TITLE
Implement lazy page navigation

### DIFF
--- a/src/examgen/gui/pages/history_page.py
+++ b/src/examgen/gui/pages/history_page.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QTableWidget,
+    QTableWidgetItem,
+    QPushButton,
+    QToolButton,
+    QMessageBox,
+    QHeaderView,
+    QAbstractItemView,
+)
+
+from sqlalchemy.orm import selectinload
+
+from examgen.core import models as m
+from examgen.core.database import SessionLocal
+from examgen.gui.dialogs.results_dialog import ResultsDialog
+
+
+class HistoryPage(QWidget):
+    """Page displaying past exam attempts."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        cols = [
+            "Materia",
+            "Inicio",
+            "Duración",
+            "Preguntas",
+            "Correctas",
+            "%",
+            "",
+            "",
+        ]
+        self.table = QTableWidget(0, len(cols), self)
+        self.table.setHorizontalHeaderLabels(cols)
+        self.table.horizontalHeader().setStretchLastSection(False)
+        self.table.verticalHeader().setVisible(False)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+
+        hh = self.table.horizontalHeader()
+        icon_w = 32
+        hh.resizeSection(6, icon_w)
+        hh.resizeSection(7, icon_w)
+        hh.setSectionResizeMode(6, QHeaderView.Fixed)
+        hh.setSectionResizeMode(7, QHeaderView.Fixed)
+
+        self.btn_clear = QPushButton("Borrar todo", clicked=self._clear_all)
+
+        root = QVBoxLayout(self)
+        root.addWidget(self.table)
+        footer = QHBoxLayout()
+        footer.addStretch(1)
+        footer.addWidget(self.btn_clear)
+        root.addLayout(footer)
+
+        self._reload_table()
+
+    # ------------------------------------------------------------------
+    def _reload_table(self) -> None:
+        with SessionLocal() as session:
+            attempts = (
+                session.query(m.Attempt)
+                .options(selectinload(m.Attempt.questions))
+                .order_by(m.Attempt.started_at.desc())
+                .all()
+            )
+
+        fmt = "%d/%m/%Y %H:%M"
+        self.table.setRowCount(len(attempts))
+        for row, at in enumerate(attempts):
+            start = at.started_at.strftime(fmt) if at.started_at else "-"
+            if at.ended_at:
+                secs = int((at.ended_at - at.started_at).total_seconds())
+                dur_txt = f"{secs//60}:{secs%60:02d} min"
+            else:
+                dur_txt = "-"
+
+            total_q = len(at.questions)
+            corr = at.score or 0
+            pct = round((corr / total_q) * 100) if total_q else 0
+
+            vals = [
+                at.subject,
+                start,
+                dur_txt,
+                str(total_q),
+                str(corr),
+                f"{pct} %",
+            ]
+            for col, val in enumerate(vals):
+                item = QTableWidgetItem(val)
+                item.setFlags(Qt.ItemIsEnabled)
+                if col == 0:
+                    item.setTextAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+                else:
+                    item.setTextAlignment(Qt.AlignCenter)
+                self.table.setItem(row, col, item)
+
+            edit_btn = QToolButton(self.table)
+            edit_btn.setIcon(QIcon.fromTheme("document-preview"))
+            edit_btn.setAutoRaise(True)
+            edit_btn.setCursor(Qt.PointingHandCursor)
+            edit_btn.clicked.connect(lambda _, a=at: self._show_results(a))
+            self.table.setCellWidget(row, 6, edit_btn)
+
+            del_btn = QToolButton(self.table)
+            del_btn.setIcon(QIcon.fromTheme("edit-delete"))
+            del_btn.setAutoRaise(True)
+            del_btn.setCursor(Qt.PointingHandCursor)
+            del_btn.clicked.connect(
+                lambda _, aid=at.id: self._delete_attempt(aid)
+            )
+            self.table.setCellWidget(row, 7, del_btn)
+
+        for c in range(self.table.columnCount()):
+            self.table.resizeColumnToContents(c)
+            w_head = self.table.horizontalHeader().sectionSizeHint(c)
+            w_cells = max(self.table.sizeHintForColumn(c), w_head)
+            self.table.setColumnWidth(c, w_cells + 12)
+
+        icon_w = 32
+        self.table.setColumnWidth(6, icon_w)
+        self.table.setColumnWidth(7, icon_w)
+
+        total_w = sum(
+            self.table.columnWidth(c) for c in range(self.table.columnCount())
+        )
+        total_w += self.table.verticalHeader().width() + 40
+        self.table.setMinimumWidth(total_w)
+        self.resize(total_w, self.height())
+
+    def _show_results(self, attempt: m.Attempt) -> None:
+        ResultsDialog.show_for_attempt(attempt, self.window())
+
+    def _delete_attempt(self, aid: int) -> None:
+        if (
+            QMessageBox.question(
+                self,
+                "Borrar examen",
+                "¿Seguro que deseas borrar este examen?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            != QMessageBox.Yes
+        ):
+            return
+        with SessionLocal() as session:
+            session.query(m.Attempt).filter_by(id=aid).delete()
+            session.commit()
+        self._reload_table()
+
+    def _clear_all(self) -> None:
+        if (
+            QMessageBox.question(
+                self,
+                "Borrar historial",
+                "¿Seguro que deseas borrar todo el historial?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            != QMessageBox.Yes
+        ):
+            return
+        with SessionLocal() as session:
+            session.query(m.Attempt).delete()
+            session.commit()
+        self._reload_table()

--- a/src/examgen/gui/pages/settings_page.py
+++ b/src/examgen/gui/pages/settings_page.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QStandardPaths, Qt
+from PySide6.QtWidgets import (
+    QWidget,
+    QComboBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from examgen.core.settings import AppSettings
+from examgen.core.database import set_engine
+
+if TYPE_CHECKING:  # pragma: no cover - circular imports only for type hints
+    from examgen.gui.windows.main_window import MainWindow  # noqa: F401
+
+
+class SettingsPage(QWidget):
+    """Editable application settings as a page."""
+
+    def __init__(
+        self, settings: AppSettings, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.settings = settings
+
+        self.cb_theme = QComboBox()
+        self.cb_theme.addItems(["dark", "light"])
+        self.cb_theme.setCurrentText(settings.theme)
+
+        self.le_db = QLineEdit(settings.data_db_path or "")
+        self.le_db.setReadOnly(True)
+        btn_choose = QPushButton("Elegir…", clicked=self._choose_db)
+        btn_save = QPushButton("Guardar", clicked=self.save_settings)
+
+        form = QFormLayout()
+        form.addRow("Tema:", self.cb_theme)
+        hb = QHBoxLayout()
+        hb.addWidget(self.le_db)
+        hb.addWidget(btn_choose)
+        form.addRow("Base de datos:", hb)
+
+        root = QVBoxLayout(self)
+        root.addLayout(form)
+        root.addWidget(btn_save, alignment=Qt.AlignRight)
+
+    # ------------------------------------------------------------------
+    def _choose_db(self) -> None:
+        start_dir = (
+            Path(self.settings.data_db_path).parent
+            if self.settings.data_db_path
+            else Path(
+                QStandardPaths.writableLocation(
+                    QStandardPaths.DocumentsLocation
+                )
+            )
+        )
+        path = QFileDialog.getExistingDirectory(
+            self,
+            "Seleccionar carpeta de datos",
+            str(start_dir),
+        )
+        if not path:
+            return
+        self.le_db.setText(str(Path(path) / "examgen.db"))
+
+    def save_settings(self) -> None:
+        self.settings.theme = self.cb_theme.currentText()
+        self.settings.data_db_path = self.le_db.text() or None
+        self.settings.save()
+        if self.settings.data_db_path:
+            set_engine(Path(self.settings.data_db_path))
+        win = self.window()
+        from examgen.gui.windows.main_window import MainWindow as MW
+
+        if isinstance(win, MW):
+            win._apply_theme()
+            win._set_app_actions_enabled(bool(self.settings.data_db_path))

--- a/src/examgen/gui/windows/main_window.py
+++ b/src/examgen/gui/windows/main_window.py
@@ -17,10 +17,10 @@ env_path = Path(__file__).resolve().parents[3] / ".env"
 load_dotenv(env_path)
 
 from examgen.core.settings import AppSettings
-from examgen.core.database import get_engine, init_db
 
 settings = AppSettings.load()
-DB_PATH = Path(settings.data_db_path or Path.home() / "Documents" / "examgen.db")
+DB_HOME = Path.home() / "Documents" / "examgen.db"
+DB_PATH = Path(settings.data_db_path or DB_HOME)
 LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING").upper()
 THEME_MAP = {"dark": "Oscuro", "light": "Claro"}
 THEME = THEME_MAP.get(settings.theme, "Oscuro")
@@ -38,17 +38,14 @@ except Exception:
 if set_theme:
     set_theme(THEME)
 
-from PySide6.QtCore import Qt
 from PySide6.QtGui import QAction, QFont
 from PySide6.QtWidgets import (
     QApplication,
-    QLabel,
     QMainWindow,
     QMenuBar,
     QStatusBar,
     QMessageBox,
     QWidget,
-    QDialog,
     QStackedWidget,
     QToolBar,
 )
@@ -81,22 +78,16 @@ class MainWindow(QMainWindow):
         nav = QToolBar("Navegación", self)
         self.addToolBar(nav)
 
-        def add_page(name: str, widget: QWidget) -> None:
-            idx = self.pages.addWidget(widget)
-            self._page_lookup[name] = widget
+        for name in ("settings", "questions", "history"):
             act = QAction(
                 name.capitalize(),
                 self,
-                triggered=lambda *, i=idx: self.pages.setCurrentIndex(i),
+                triggered=lambda _, n=name: self._show_page(n),
             )
             nav.addAction(act)
 
-        # registrar páginas
-        from examgen.gui.pages.questions_page import QuestionsPage
-        add_page("questions", QuestionsPage(self))
-
         # página inicial
-        self.pages.setCurrentWidget(self._page_lookup["questions"])
+        self._show_page("questions")
 
         # Menú y barra de estado
         self._create_menu_bar()
@@ -113,7 +104,8 @@ class MainWindow(QMainWindow):
         # --- Archivo ------------------------------------------------------ #
         menu_file = mb.addMenu("Archivo")
 
-        act_settings = QAction("Configuración…", self, triggered=self._open_settings)
+        act_settings = QAction("Configuración…", self)
+        act_settings.triggered.connect(lambda: self._show_page("settings"))
         act_exit = QAction("Salir", self, triggered=self.close)
 
         menu_file.addAction(act_settings)
@@ -123,11 +115,20 @@ class MainWindow(QMainWindow):
         # --- Aplicación --------------------------------------------------- #
         self.menu_app = mb.addMenu("Aplicación")
 
-        self.act_exam = QAction("Hacer examen…", self, triggered=self._start_exam)
-        self.act_questions = QAction("Preguntas", self, triggered=self._show_questions)
-        self.act_history = QAction("Historial", self, triggered=self._show_history)
+        self.act_exam = QAction("Hacer examen…", self)
+        self.act_exam.triggered.connect(self._start_exam)
+        self.act_questions = QAction("Preguntas", self)
+        self.act_questions.triggered.connect(
+            lambda: self._show_page("questions")
+        )
+        self.act_history = QAction("Historial", self)
+        self.act_history.triggered.connect(
+            lambda: self._show_page("history")
+        )
 
-        self.menu_app.addActions([self.act_exam, self.act_questions, self.act_history])
+        self.menu_app.addActions(
+            [self.act_exam, self.act_questions, self.act_history]
+        )
 
         self.menu_app.aboutToShow.connect(self._warn_if_disabled)
 
@@ -148,11 +149,7 @@ class MainWindow(QMainWindow):
                 )
 
     def _open_settings(self) -> None:
-        from examgen.gui.dialogs.settings_dialog import SettingsDialog
-
-        dlg = SettingsDialog(self.settings, self)
-        if dlg.exec() == QDialog.Accepted:
-            self._set_app_actions_enabled(bool(self.settings.data_db_path))
+        self._show_page("settings")
 
     def _set_app_actions_enabled(self, enabled: bool) -> None:
         for act in (self.act_exam, self.act_questions, self.act_history):
@@ -163,7 +160,10 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(
                 self,
                 "Base de datos no seleccionada",
-                "Primero selecciona una base de datos en Archivo \u25ba Configuraci\u00f3n.",
+                (
+                    "Primero selecciona una base de datos en "
+                    "Archivo \u25ba Configuración."
+                ),
             )
             self.menu_app.hideTearOffMenu()
 
@@ -185,6 +185,29 @@ class MainWindow(QMainWindow):
         if app is not None:
             app.setStyleSheet(Style.sheet(self.current_theme) + BUTTON_STYLE)
 
+    # ------------------------------------------------------------------ #
+    #  Navegación                                                        #
+    # ------------------------------------------------------------------ #
+    def _show_page(self, name: str) -> None:
+        if name not in self._page_lookup:
+            if name == "questions":
+                from examgen.gui.pages.questions_page import QuestionsPage
+
+                widget = QuestionsPage(self)
+            elif name == "history":
+                from examgen.gui.pages.history_page import HistoryPage
+
+                widget = HistoryPage(self)
+            elif name == "settings":
+                from examgen.gui.pages.settings_page import SettingsPage
+
+                widget = SettingsPage(self.settings, self)
+            else:
+                return
+            self._page_lookup[name] = widget
+            self.pages.addWidget(widget)
+        self.pages.setCurrentWidget(self._page_lookup[name])
+
     # --------------------------------------------------------------------- #
     #  Diálogo de pregunta                                                  #
     # --------------------------------------------------------------------- #
@@ -192,12 +215,10 @@ class MainWindow(QMainWindow):
         QuestionDialog(self, db_path=DB_PATH).exec()
 
     def _show_questions(self) -> None:
-        self.pages.setCurrentWidget(self._page_lookup["questions"])
+        self._show_page("questions")
 
     def _show_history(self) -> None:
-        from examgen.gui.dialogs.history_dialog import AttemptsHistoryDialog
-
-        AttemptsHistoryDialog(self).exec()
+        self._show_page("history")
 
 
 # ------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- add HistoryPage and SettingsPage widgets
- lazy load pages in main window with `_show_page`
- update navigation actions to switch pages

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684d5bfe134883298a0ee338fd32b204