### PR TITLE
Unify menu bar and adjust pages

### DIFF
--- a/src/examgen/gui/pages/history_page.py
+++ b/src/examgen/gui/pages/history_page.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QHeaderView,
     QAbstractItemView,
+    QSizePolicy,
 )
 
 from sqlalchemy.orm import selectinload
@@ -54,6 +55,10 @@ class HistoryPage(QWidget):
         self.btn_clear = QPushButton("Borrar todo", clicked=self._clear_all)
 
         root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(8)
+        self.table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         root.addWidget(self.table)
         footer = QHBoxLayout()
         footer.addStretch(1)

--- a/src/examgen/gui/pages/questions_page.py
+++ b/src/examgen/gui/pages/questions_page.py
@@ -67,7 +67,7 @@ class QuestionsPage(QWidget):
         self.table = QTableWidget(0, len(headers))
         self.table.setHorizontalHeaderLabels(headers)
         hh = self.table.horizontalHeader()
-        hh.setStretchLastSection(True)
+        hh.setSectionResizeMode(QHeaderView.Stretch)
         self.table.verticalHeader().setVisible(False)
         self.table.setWordWrap(True)
         self.table.setShowGrid(True)
@@ -83,8 +83,8 @@ class QuestionsPage(QWidget):
         splitter = QSplitter(Qt.Horizontal, self)
 
         root = QVBoxLayout(self)
-        root.setContentsMargins(8, 8, 8, 8)
-        root.setSpacing(4)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(8)
         root.addLayout(top)
         root.addWidget(splitter)
 

--- a/src/examgen/gui/windows/main_window.py
+++ b/src/examgen/gui/windows/main_window.py
@@ -47,7 +47,6 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QWidget,
     QStackedWidget,
-    QToolBar,
 )
 
 from examgen.core import models as m
@@ -74,17 +73,7 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.pages)
         self._page_lookup: dict[str, QWidget] = {}
 
-        # --- barra de navegación ---
-        nav = QToolBar("Navegación", self)
-        self.addToolBar(nav)
-
-        for name in ("settings", "questions", "history"):
-            act = QAction(
-                name.capitalize(),
-                self,
-                triggered=lambda _, n=name: self._show_page(n),
-            )
-            nav.addAction(act)
+        # -- las páginas se eligen desde el menú principal --
 
         # página inicial
         self._show_page("questions")
@@ -131,6 +120,13 @@ class MainWindow(QMainWindow):
         )
 
         self.menu_app.aboutToShow.connect(self._warn_if_disabled)
+
+        self._menu_actions = {
+            "config": act_settings,
+            "exam": self.act_exam,
+            "questions": self.act_questions,
+            "history": self.act_history,
+        }
 
     def _start_exam(self) -> None:
         from examgen.gui.dialogs.question_dialog import ExamConfigDialog
@@ -206,7 +202,8 @@ class MainWindow(QMainWindow):
                 return
             self._page_lookup[name] = widget
             self.pages.addWidget(widget)
-        self.pages.setCurrentWidget(self._page_lookup[name])
+        if self.pages.currentWidget() is not self._page_lookup[name]:
+            self.pages.setCurrentWidget(self._page_lookup[name])
 
     # --------------------------------------------------------------------- #
     #  Diálogo de pregunta                                                  #


### PR DESCRIPTION
## Summary
- remove redundant navigation toolbar
- consolidate application actions in main menu
- tweak page layouts for better resizing

## Testing
- `flake8 src/examgen/gui/windows/main_window.py src/examgen/gui/pages/questions_page.py src/examgen/gui/pages/history_page.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684d6576918c8329b60256db6031f890