### PR TITLE
Integrate exam page in main window

### DIFF
--- a/src/examgen/gui/pages/exam_page.py
+++ b/src/examgen/gui/pages/exam_page.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable
+import random
+
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtGui import QKeySequence, QShortcut
+from PySide6.QtWidgets import (
+    QAbstractButton,
+    QButtonGroup,
+    QCheckBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QRadioButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from examgen.core.models import Attempt, AttemptQuestion
+from examgen.core.database import SessionLocal
+from examgen.core.services.exam_service import evaluate_attempt
+from examgen.gui.dialogs.results_dialog import ResultsDialog
+
+
+@dataclass(slots=True)
+class OptionWidgetInfo:
+    widget: QAbstractButton
+    letter: str
+    is_correct: bool
+    explanation: str
+    label_exp: QLabel
+
+
+class ExamPage(QWidget):
+    """Exam view integrated as a page."""
+
+    def __init__(
+        self,
+        attempt: Attempt,
+        on_finished: Callable[[], None] | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.attempt = attempt
+        self.on_finished = on_finished
+        self.remaining_seconds = attempt.time_limit * 60
+        self.index = 0
+        self.expl_shown = False
+        self.num_correct = 0
+        self.current_aq: AttemptQuestion | None = None
+
+        self.lbl_subject = QLabel(f"Materia: {attempt.subject}")
+        self.lbl_timer = QLabel(alignment=Qt.AlignRight)
+        self.lbl_progress = QLabel(alignment=Qt.AlignCenter)
+        self.btn_pause = QPushButton("Pausar", clicked=self._toggle_pause)
+        self.btn_toggle = QPushButton("Revisar Explicación \u25bc")
+        self.btn_toggle.clicked.connect(self._toggle_expl)
+        self.btn_toggle.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        header.addWidget(self.lbl_subject)
+        header.addStretch(1)
+        header.addWidget(self.lbl_progress)
+        header.addStretch(1)
+        header.addWidget(self.lbl_timer)
+
+        header2 = QHBoxLayout()
+        header2.setContentsMargins(0, 0, 0, 0)
+        header2.addWidget(self.btn_pause)
+        header2.addStretch(1)
+        header2.addWidget(self.btn_toggle)
+
+        self.lbl_prompt = QLabel(alignment=Qt.AlignJustify)
+        self.lbl_prompt.setWordWrap(True)
+        self.lbl_prompt.setContentsMargins(0, 4, 0, 12)
+        self.lbl_prompt.setSizePolicy(
+            QSizePolicy.Expanding,
+            QSizePolicy.Minimum,
+        )
+        self.group = QButtonGroup(self)
+        self.options: list[OptionWidgetInfo] = []
+
+        opts_container = QWidget()
+        self.vbox_opts = QVBoxLayout(opts_container)
+        self.vbox_opts.setContentsMargins(0, 0, 0, 0)
+
+        nav = QHBoxLayout()
+        self.btn_prev = QPushButton("\u2190 Anterior", clicked=self._prev)
+        self.btn_next = QPushButton("Siguiente \u2192", clicked=self._next)
+        nav.addWidget(self.btn_prev)
+        nav.addStretch(1)
+        nav.addWidget(self.btn_next)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(8, 4, 8, 8)
+        root.setSpacing(4)
+        root.addLayout(header)
+        root.addLayout(header2)
+        root.addWidget(self.lbl_prompt)
+        root.addWidget(opts_container)
+        root.addLayout(nav)
+
+        QShortcut(
+            QKeySequence("Ctrl+P"),
+            self,
+            activated=self._toggle_pause,
+        )
+        QShortcut(
+            QKeySequence("Ctrl+Return"),
+            self,
+            activated=self._finish_shortcut,
+        )
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self._tick)
+        self.timer.start(1000)
+
+        self._load_question()
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _fmt(secs: int) -> str:
+        m, s = divmod(max(secs, 0), 60)
+        return f"Tiempo: {m:02d}:{s:02d}"
+
+    def _update_timer(self) -> None:
+        self.lbl_timer.setText(self._fmt(self.remaining_seconds))
+
+    def _update_check_state(self, changed_box: QCheckBox) -> None:
+        sel_boxes = [
+            i
+            for i in self.options
+            if isinstance(i.widget, QCheckBox) and i.widget.isChecked()
+        ]
+        if len(sel_boxes) > self.num_correct:
+            changed_box.setChecked(False)
+            QMessageBox.information(
+                self,
+                "Máximo alcanzado",
+                (
+                    f"Solo puedes elegir {self.num_correct} "
+                    "opciones en esta pregunta."
+                ),
+            )
+            sel_boxes.pop()
+        ready = len(sel_boxes) == self.num_correct
+        self.btn_toggle.setEnabled(ready)
+        self.btn_next.setEnabled(ready)
+
+    def _set_widgets_enabled(self, enabled: bool) -> None:
+        for info in self.options:
+            w = info.widget
+            w.setAttribute(Qt.WA_TransparentForMouseEvents, not enabled)
+            w.setFocusPolicy(Qt.StrongFocus if enabled else Qt.NoFocus)
+        if enabled:
+            self.btn_prev.setEnabled(self.index > 0)
+            if isinstance(self.options[0].widget, QRadioButton):
+                self.btn_next.setEnabled(True)
+                self.btn_toggle.setEnabled(self._has_expl)
+            else:
+                self._update_check_state(self.options[0].widget)
+        else:
+            self.btn_prev.setEnabled(False)
+            self.btn_next.setEnabled(False)
+            self.btn_toggle.setEnabled(False)
+
+    def _tick(self) -> None:
+        self.remaining_seconds -= 1
+        self._update_timer()
+        if self.remaining_seconds <= 0:
+            self.finish_exam(auto=True)
+
+    def _save_selection(self) -> None:
+        aq = self.attempt.questions[self.index]
+        if not self.options:
+            return
+        if isinstance(self.options[0].widget, QRadioButton):
+            sel = next(
+                (i.letter for i in self.options if i.widget.isChecked()),
+                "",
+            )
+        else:
+            sel = "".join(
+                sorted(
+                    i.letter for i in self.options if i.widget.isChecked()
+                )
+            )
+        aq.selected_option = sel
+        with SessionLocal() as s:
+            s.merge(aq)
+            s.commit()
+
+    # ------------------------ nav & display ----------------------------
+    def _load_question(self) -> None:
+        self._update_timer()
+        total = len(self.attempt.questions)
+        self.lbl_progress.setText(f"Pregunta {self.index + 1} / {total}")
+
+        aq = self.attempt.questions[self.index]
+        self.current_aq = aq
+        self.expl_shown = False
+        self.lbl_prompt.setText(aq.question.prompt)
+        self.lbl_prompt.adjustSize()
+        has_expl = bool(
+            aq.question.explanation and aq.question.explanation.strip()
+        )
+        self._has_expl = has_expl
+        self.btn_toggle.setEnabled(has_expl)
+        self.btn_toggle.setToolTip(
+            "" if has_expl else "Esta pregunta no tiene explicación guardada"
+        )
+        self.btn_toggle.setText("Revisar Explicación \u25bc")
+        self.btn_toggle.setEnabled(False)
+        self.btn_next.setEnabled(False)
+
+        options: list[tuple[str, str, bool, str]] = [
+            (
+                letter,
+                opt.text,
+                opt.is_correct,
+                opt.explanation or "",
+            )
+            for letter, opt in aq.question.options_dict.items()
+            if opt.text
+        ]
+        random.shuffle(options)
+        self.num_correct = sum(1 for _, _, ok, _ in options if ok)
+        widget_cls = QRadioButton if self.num_correct == 1 else QCheckBox
+
+        for i in reversed(range(self.vbox_opts.count())):
+            item = self.vbox_opts.takeAt(i)
+            if item.widget():
+                item.widget().deleteLater()
+
+        self.options.clear()
+        if widget_cls is QRadioButton:
+            self.group = QButtonGroup(self)
+        for letter, text, is_ok, expl in options:
+            w = widget_cls(text, self)
+            if isinstance(w, QRadioButton):
+                self.group.addButton(w)
+            info = OptionWidgetInfo(
+                widget=w,
+                letter=letter,
+                is_correct=is_ok,
+                explanation=expl,
+                label_exp=QLabel(expl, self),
+            )
+            info.label_exp.setWordWrap(True)
+            info.label_exp.setObjectName("OptExplanation")
+            info.label_exp.setVisible(False)
+            self.options.append(info)
+            self.vbox_opts.addWidget(w)
+            self.vbox_opts.addWidget(info.label_exp)
+            if isinstance(w, QRadioButton):
+                w.setChecked(aq.selected_option == letter)
+            else:
+                w.setChecked(letter in (aq.selected_option or ""))
+                w.stateChanged.connect(
+                    lambda _, b=w: self._update_check_state(b)
+                )
+        self.btn_prev.setEnabled(self.index > 0)
+        if self.index == total - 1:
+            self.btn_next.setText("Finalizar")
+        else:
+            self.btn_next.setText("Siguiente \u2192")
+
+        if widget_cls is QRadioButton:
+            self.btn_toggle.setEnabled(has_expl)
+            self.btn_next.setEnabled(True)
+        else:
+            self._update_check_state(self.options[0].widget)
+
+    def _toggle_pause(self) -> None:
+        if self.timer.isActive():
+            self.timer.stop()
+            self._set_widgets_enabled(False)
+            self.btn_pause.setText("Reanudar")
+        else:
+            if self.remaining_seconds <= 0:
+                return
+            self.timer.start(1000)
+            self._set_widgets_enabled(True)
+            self.btn_pause.setText("Pausar")
+
+    def _finish_shortcut(self) -> None:
+        if self.index == len(self.attempt.questions) - 1:
+            self._next()
+
+    def _toggle_expl(self) -> None:
+        if not self.expl_shown:
+            self._save_selection()
+            self._evaluate_selection(self.current_aq)
+            self._apply_colors(self.current_aq)
+            self._freeze_options()
+            for info in self.options:
+                info.label_exp.setVisible(bool(info.label_exp.text().strip()))
+            self.expl_shown = True
+            self.btn_toggle.setText("Ocultar Explicación \u25b2")
+        else:
+            for info in self.options:
+                info.label_exp.setVisible(False)
+            self.expl_shown = False
+            self.btn_toggle.setText("Revisar Explicación \u25bc")
+
+    def _prev(self) -> None:
+        if self.index == 0:
+            return
+        self._save_selection()
+        self.index -= 1
+        self._load_question()
+
+    def _next(self) -> None:
+        self._save_selection()
+        if self.index < len(self.attempt.questions) - 1:
+            self.index += 1
+            self._load_question()
+        else:
+            reply = QMessageBox.question(
+                self,
+                "Entregar examen",
+                "¿Seguro que deseas entregar el examen?",
+                QMessageBox.Yes | QMessageBox.No,
+            )
+            if reply == QMessageBox.Yes:
+                self.finish_exam(auto=False)
+
+    def _freeze_options(self) -> None:
+        for info in self.options:
+            info.widget.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+            info.widget.setFocusPolicy(Qt.NoFocus)
+
+    def _evaluate_selection(self, aq: AttemptQuestion) -> None:
+        correct_set = {
+            letter
+            for letter, opt in zip("ABCDE", aq.question.options)
+            if opt.is_correct
+        }
+        if isinstance(self.options[0].widget, QRadioButton):
+            aq.is_correct = aq.selected_option in correct_set
+        else:
+            aq.is_correct = set(aq.selected_option or "") == correct_set
+        with SessionLocal() as s:
+            s.merge(aq)
+            s.commit()
+
+    def _apply_colors(self, aq: AttemptQuestion) -> None:
+        sel_set = set(aq.selected_option or "")
+        for info in self.options:
+            color = None
+            if info.is_correct:
+                color = "#5af16a"  # verde
+            elif info.letter in sel_set:
+                color = "#ff6b6b"  # rojo
+            if color:
+                info.widget.setStyleSheet(f"color: {color};")
+            else:
+                info.widget.setStyleSheet("")
+            info.widget.setText(info.widget.text())
+            info.widget.adjustSize()
+            info.widget.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+            info.widget.setFocusPolicy(Qt.NoFocus)
+
+    # ------------------------ finish ----------------------
+    def finish_exam(self, auto: bool) -> None:
+        if self.attempt.ended_at is not None:
+            return
+        if self.timer.isActive():
+            self.timer.stop()
+        self._save_selection()
+        self.attempt.ended_at = datetime.utcnow()
+        with SessionLocal() as s:
+            s.merge(self.attempt)
+            s.commit()
+
+        self.attempt = evaluate_attempt(self.attempt.id)
+
+        def _show() -> None:
+            ResultsDialog.show_for_attempt(self.attempt, self)
+            if self.on_finished:
+                self.on_finished()
+
+        QTimer.singleShot(0, _show)


### PR DESCRIPTION
## Summary
- add `ExamPage` widget to show exams within the stacked interface
- start exam from `MainWindow` using `ExamPage`

## Testing
- `flake8 src/examgen/gui/pages/exam_page.py src/examgen/gui/windows/main_window.py`
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d7480d7548329b71e95961bb26c97