### PR TITLE
Fix attempt deletion cascade

### DIFF
--- a/src/examgen/gui/pages/history_page.py
+++ b/src/examgen/gui/pages/history_page.py
@@ -157,8 +157,10 @@ class HistoryPage(QWidget):
         ):
             return
         with SessionLocal() as session:
-            session.query(m.Attempt).filter_by(id=aid).delete()
-            session.commit()
+            attempt = session.get(m.Attempt, aid)
+            if attempt:
+                session.delete(attempt)
+                session.commit()
         self._reload_table()
 
     def _clear_all(self) -> None:
@@ -174,6 +176,8 @@ class HistoryPage(QWidget):
         ):
             return
         with SessionLocal() as session:
-            session.query(m.Attempt).delete()
+            attempts = session.query(m.Attempt).all()
+            for attempt in attempts:
+                session.delete(attempt)
             session.commit()
         self._reload_table()


### PR DESCRIPTION
## Summary
- ensure ORM cascade when deleting attempts

## Testing
- `flake8 src/ tests/ | head -n 20`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684d9dec5c508329b62c252b87a91912