### PR TITLE
Fix review explanation button logic

### DIFF
--- a/src/examgen/gui/pages/exam_page.py
+++ b/src/examgen/gui/pages/exam_page.py
@@ -158,8 +158,11 @@ class ExamPage(QWidget):
 
     @Slot()
     def _actualizar_estado_botones(self) -> None:
+        # Está completo si el número de selecciones coincide con lo que
+        # pide la pregunta
         completado = self._selecciones_actuales() == self.num_correct
-        self.btn_toggle.setEnabled(completado and self._has_expl)
+        # El alumno debe poder pulsar el botón aunque la explicación esté vacía
+        self.btn_toggle.setEnabled(completado)
         self.btn_next.setEnabled(completado)
 
     @Slot()
@@ -294,8 +297,7 @@ class ExamPage(QWidget):
         else:
             self.btn_next.setText("Siguiente \u2192")
 
-        if self.num_correct == 1 and self.group:
-            self.group.buttonToggled.connect(self._on_opcion_toggled)
+        # Con radios ya recibimos 'toggled' de cada botón; no duplicar.
         if self.options:
             self._on_opcion_toggled()
 


### PR DESCRIPTION
## Summary
- habilitar el botón "Revisar Explicación" incluso si la pregunta no tiene texto
- evitar la conexión duplicada de señales en opciones de respuesta única

## Testing
- `flake8 src/examgen/gui/pages/exam_page.py`
- `pytest -q` *(falla: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684daf6152d083299d0d1b314a854078