### PR TITLE
feat(gui): polish exam page layout and shortcuts

### DIFF
--- a/src/examgen/ui/styles.py
+++ b/src/examgen/ui/styles.py
@@ -39,7 +39,17 @@ QLabel#OptExplanation {
 }
 """
 
+EXPLANATION_BOX_STYLE = """
+QFrame#explanationBox {
+    border: 1px solid #4caf50;
+    background: #1a1a1a;
+    border-radius: 4px;
+    padding: 4px 8px;
+}
+QLabel#explanationLabel { color: #4caf50; }
+"""
+
 
 def apply_app_styles(app: QApplication) -> None:
     """Apply global styles to *app*."""
-    app.setStyleSheet(BUTTON_STYLE + OPTION_EXPL_STYLE)
+    app.setStyleSheet(BUTTON_STYLE + OPTION_EXPL_STYLE + EXPLANATION_BOX_STYLE)


### PR DESCRIPTION
## Summary
- tweak header font and add clock emoji in timer
- show explanations in framed boxes with success/fail icons
- add keyboard shortcuts and pause button style tweaks

## Testing
- `flake8 src/ tests/`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684db95280b483299c7df41da4296daa