### PR TITLE
Enhance exam page with progress and animated explanation

### DIFF
--- a/src/examgen/gui/__init__.py
+++ b/src/examgen/gui/__init__.py
@@ -1,3 +1,5 @@
-"""UI package."""
+"""UI package with embedded Qt resources."""
+
+from . import resources_rc  # noqa: F401
 
 __all__: list[str] = []

--- a/src/examgen/gui/icons/icon_finish.svg
+++ b/src/examgen/gui/icons/icon_finish.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M9 16.2l-3.5-3.5-1.4 1.4L9 19 20.3 7.7l-1.4-1.4z" fill="#4caf50"/>
+</svg>

--- a/src/examgen/gui/pages/exam_page.qss
+++ b/src/examgen/gui/pages/exam_page.qss
@@ -1,0 +1,13 @@
+QFrame#explanationBox {
+    border: 1px solid #4caf50;
+    background: #1a1a1a;
+    border-radius: 6px;
+    padding: 4px 8px;
+}
+QLabel#explanationLabel {
+    color: #4caf50;
+    margin-left: 6px;
+}
+QAbstractButton#optionButton:hover {
+    background: #222;
+}

--- a/src/examgen/gui/resources.qrc
+++ b/src/examgen/gui/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/icons">
+        <file>icons/icon_finish.svg</file>
+    </qresource>
+</RCC>

--- a/src/examgen/gui/resources_rc.py
+++ b/src/examgen/gui/resources_rc.py
@@ -1,0 +1,51 @@
+# Resource object code (Python 3)
+# Created by: object code
+# Created by: The Resource Compiler for Qt version 6.9.1
+# WARNING! All changes made in this file will be lost!
+
+from PySide6 import QtCore
+
+qt_resource_data = b"\
+\x00\x00\x00\x92\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 viewBox=\x22\
+0 0 24 24\x22>\x0a  <p\
+ath d=\x22M9 16.2l-\
+3.5-3.5-1.4 1.4L\
+9 19 20.3 7.7l-1\
+.4-1.4z\x22 fill=\x22#\
+4caf50\x22/>\x0a</svg>\
+\x0a\
+"
+
+qt_resource_name = b"\
+\x00\x05\
+\x00o\xa6S\
+\x00i\
+\x00c\x00o\x00n\x00s\
+\x00\x0f\
+\x0c\x11|\xe7\
+\x00i\
+\x00c\x00o\x00n\x00_\x00f\x00i\x00n\x00i\x00s\x00h\x00.\x00s\x00v\x00g\
+"
+
+qt_resource_struct = b"\
+\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x01\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x03\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x10\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\
+\x00\x00\x01\x97o\xae(\xce\
+"
+
+def qInitResources():
+    QtCore.qRegisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+
+def qCleanupResources():
+    QtCore.qUnregisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+
+qInitResources()


### PR DESCRIPTION
## Summary
- load embedded Qt resources
- add progress bar and improved timer color logic
- add global explanation box with animation
- style hover for options via new QSS
- include finish icon through resources.qrc

## Testing
- `flake8 src/ tests/ | head`
- `QT_QPA_PLATFORM=offscreen pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684dbcf4c9048329abb07d86e265c789