### PR TITLE
Animate option explanations

### DIFF
--- a/src/examgen/gui/pages/exam_page.qss
+++ b/src/examgen/gui/pages/exam_page.qss
@@ -1,13 +1,14 @@
-QFrame#explanationBox {
+QAbstractButton {
+    padding: 4px 6px;
+}
+QAbstractButton:hover {
+    background: #212121;
+}
+QFrame#explFrame {
     border: 1px solid #4caf50;
-    background: #1a1a1a;
+    background: #141414;
     border-radius: 6px;
-    padding: 4px 8px;
 }
-QLabel#explanationLabel {
+QLabel#lblExpl {
     color: #4caf50;
-    margin-left: 6px;
-}
-QAbstractButton#optionButton:hover {
-    background: #222;
 }


### PR DESCRIPTION
## Summary
- tweak exam page layout spacing
- show per-option explanations with smooth expand and auto-scroll
- update tooltips to hint at new shortcut
- compact styles for options/explanations

## Testing
- `flake8 src/ tests/` *(fails: E501 line too long, etc.)*
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684dc1565ae08329a03dd07c28789aa9