### PR TITLE
feat(gui): expand explanations simultaneously

### DIFF
--- a/src/examgen/gui/pages/exam_page.qss
+++ b/src/examgen/gui/pages/exam_page.qss
@@ -4,11 +4,10 @@ QAbstractButton {
 QAbstractButton:hover {
     background: #212121;
 }
-QFrame#explFrame {
-    border: 1px solid #4caf50;
-    background: #141414;
-    border-radius: 6px;
+QFrame#explFrame{
+    border:1px solid #4caf50;
+    background:#141414;
+    border-radius:6px;
+    padding:4px 6px;
 }
-QLabel#lblExpl {
-    color: #4caf50;
-}
+QLabel#lblExpl{ color:#4caf50; }


### PR DESCRIPTION
## Summary
- toggle all explanations at once with animation and preserve evaluation
- compact spacing and new QSS style

## Testing
- `flake8 src/ tests/` *(fails: E501 and other issues)*
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684dcabf1668832986c6ee753c91e9d6