### PR TITLE
Dynamic color for option explanations

### DIFF
--- a/src/examgen/gui/pages/exam_page.py
+++ b/src/examgen/gui/pages/exam_page.py
@@ -371,6 +371,15 @@ class ExamPage(QWidget):
             lbl = QLabel(expl, self, objectName="lblExpl")
             lbl.setWordWrap(True)
             lay.addWidget(lbl)
+
+            border = "#4caf50" if is_ok else "#e53935"
+            frame.setStyleSheet(
+                f"border:1px solid {border};"
+                f"background:#141414;"
+                f"border-radius:6px;"
+                f"color:{border};"
+            )
+            lbl.setStyleSheet(f"color:{border};")
             info = OptionWidgetInfo(
                 widget=w,
                 letter=letter,


### PR DESCRIPTION
## Summary
- colorize explanation frames dynamically in `ExamPage`

## Testing
- `flake8 src/ tests/` *(fails: E501 and others)*
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684dcedf7f6c8329bef4375e2620eb83