### PR TITLE
Use platformdirs for user config and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,9 @@ cython_debug/
 
 # DB files
 *.db
+
+# config y logs locales
+**/__pycache__/
+*.log
+~/.config/ExamGen/
+~/.local/state/ExamGen/

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ mypy>=1.10
 pydantic>=2.6
 faker>=25.2
 flake8>=7.0
+platformdirs>=4.0

--- a/src/examgen/__init__.py
+++ b/src/examgen/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+"""ExamGen package initialization."""
+
+from examgen.utils.logger import set_logging
+
+set_logging()
+
+__all__ = ["set_logging"]

--- a/src/examgen/core/migrations/add_section.py
+++ b/src/examgen/core/migrations/add_section.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from sqlalchemy import create_engine
 
-from examgen.core.settings import AppSettings
+from examgen.config import AppSettings
 
 
 def run() -> None:

--- a/src/examgen/core/migrations/fix_attempt_fk.py
+++ b/src/examgen/core/migrations/fix_attempt_fk.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
     create_engine,
 )
 
-from examgen.core.settings import AppSettings
+from examgen.config import AppSettings
 
 
 def run() -> None:

--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -6,8 +6,13 @@ from pathlib import Path
 
 from PySide6.QtWidgets import QApplication
 
-from examgen.core.database import get_engine, init_db, run_migrations, set_engine
-from examgen.core.settings import settings
+from examgen.core.database import (
+    get_engine,
+    init_db,
+    run_migrations,
+    set_engine,
+)
+from examgen.config import settings
 
 
 db_path = Path(settings.data_db_path or Path.home() / "Documents" / "examgen.db")

--- a/src/examgen/gui/dialogs/settings_dialog.py
+++ b/src/examgen/gui/dialogs/settings_dialog.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from examgen.core.settings import AppSettings
+from examgen.config import AppSettings
 from examgen.core.database import set_engine
 
 

--- a/src/examgen/gui/pages/settings_page.py
+++ b/src/examgen/gui/pages/settings_page.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from examgen.core.settings import AppSettings
+from examgen.config import AppSettings
 from examgen.core.database import set_engine
 
 if TYPE_CHECKING:  # pragma: no cover - circular imports only for type hints

--- a/src/examgen/gui/windows/main_window.py
+++ b/src/examgen/gui/windows/main_window.py
@@ -16,18 +16,18 @@ import os
 env_path = Path(__file__).resolve().parents[3] / ".env"
 load_dotenv(env_path)
 
-from examgen.core.settings import settings
+from examgen.config import settings
 DB_HOME = Path.home() / "Documents" / "examgen.db"
 DB_PATH = Path(settings.data_db_path or DB_HOME)
 LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING").upper()
 THEME_MAP = {"dark": "Oscuro", "light": "Claro"}
 THEME = THEME_MAP.get(settings.theme, "Oscuro")
 
-logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.WARNING))
+logger = logging.getLogger(__name__)
 if LOG_LEVEL == "DEBUG":
-    print(f"Loaded .env from {env_path}")
-    print(f"DB path: {DB_PATH}")
-    print(f"Theme  : {THEME}")
+    logger.debug("Loaded .env from %s", env_path)
+    logger.debug("DB path: %s", DB_PATH)
+    logger.debug("Theme  : %s", THEME)
 
 try:
     from examgen.config import set_theme  # type: ignore

--- a/src/examgen/utils/debug.py
+++ b/src/examgen/utils/debug.py
@@ -1,4 +1,4 @@
-from examgen.core.settings import settings
+from examgen.config import settings
 
 
 def log(msg: str) -> None:

--- a/src/examgen/utils/logger.py
+++ b/src/examgen/utils/logger.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from platformdirs import user_log_dir
+
+
+def set_logging() -> None:
+    log_dir = Path(user_log_dir("ExamGen"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / f"examgen_{datetime.now():%Y%m%d_%H%M}.log"
+    handlers = [
+        logging.StreamHandler(sys.stdout),
+        RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3),
+    ]
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=handlers,
+    )


### PR DESCRIPTION
## Summary
- add `platformdirs` dependency
- move settings handling to new `examgen.config` using user config dir
- initialize logging in `examgen.__init__` with rotating file handler
- centralize logging setup in `utils/logger.py`
- update imports to the new `config` module
- ignore local config and log directories

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684ea4309374832986a471e552a67388