### PR TITLE
Implement initial DB in user config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,11 +173,8 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-# DB files
+# directorio de config/log locales
+**/ExamGen/
 *.db
-
-# config y logs locales
 **/__pycache__/
 *.log
-~/.config/ExamGen/
-~/.local/state/ExamGen/

--- a/src/examgen/core/database.py
+++ b/src/examgen/core/database.py
@@ -7,16 +7,24 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
-from examgen.utils.debug import log
 from examgen.config import DEFAULT_DB
+from examgen.utils.debug import log
 
 from examgen.core.models import Base, _create_examiner_tables
 
 
-_engine: Engine | None = None
-SessionLocal = sessionmaker(expire_on_commit=False, future=True)
-
 LEGACY_DB = Path("examgen.db")
+
+if LEGACY_DB.exists() and not DEFAULT_DB.exists():
+    LEGACY_DB.rename(DEFAULT_DB)
+
+if not DEFAULT_DB.exists():
+    DEFAULT_DB.touch()
+
+engine = create_engine(f"sqlite:///{DEFAULT_DB}", future=True)
+SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+_engine: Engine | None = engine
 
 
 def set_engine(db_path: Path | None = None) -> None:


### PR DESCRIPTION
## Summary
- ensure a default database is created beside settings
- keep legacy database migration
- ignore local config directories and DB files

## Testing
- `flake8 src/ tests/` *(fails: E501 lines too long, E302, etc.)*
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684eb3b7b8c083298428152fb2c55640