### PR TITLE
Enforce unique exam question pairs

### DIFF
--- a/src/examgen/core/migrations/__init__.py
+++ b/src/examgen/core/migrations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from . import create_schema, add_section
+from . import create_schema, add_section, unique_exam_question
 
 # Each migration module exposes:
 #   requires: set[str]  -- tables needed
@@ -8,6 +8,7 @@ from . import create_schema, add_section
 #   def run() -> None   -- perform migration
 
 MIGRATIONS = (
-    create_schema,  # provides base tables
-    add_section,    # requires question
+    create_schema,      # provides base tables
+    add_section,        # requires question
+    unique_exam_question,  # add unique index to exam_question
 )

--- a/src/examgen/core/migrations/unique_exam_question.py
+++ b/src/examgen/core/migrations/unique_exam_question.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+from sqlalchemy import create_engine
+
+from examgen.config import AppSettings
+
+requires: set[str] = {"exam_question"}
+provides: set[str] = set()
+
+
+def run() -> None:
+    """Add unique index on (exam_id, question_id) if missing."""
+    db_path = Path(
+        AppSettings.load().data_db_path or Path.home() / "Documents" / "examgen.db"
+    )
+    eng = create_engine(f"sqlite:///{db_path}", future=True)
+    index_name = "uq_exam_question"
+    with eng.begin() as conn:
+        indexes = {
+            row[1] for row in conn.exec_driver_sql("PRAGMA index_list('exam_question')")
+        }
+        if index_name not in indexes:
+            conn.exec_driver_sql(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {index_name} ON exam_question (exam_id, question_id)"
+            )

--- a/src/examgen/core/models.py
+++ b/src/examgen/core/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     JSON,
     String,
     Text,
+    UniqueConstraint,
     create_engine,
     Enum as SQLAEnum,
     inspect,
@@ -136,6 +137,7 @@ class AnswerOption(Base):
 
 class ExamQuestion(Base):
     __tablename__ = "exam_question"
+    __table_args__ = (UniqueConstraint("exam_id", "question_id"),)
 
     exam_id: Mapped[int] = mapped_column(ForeignKey("exam.id"), nullable=False)
     question_id: Mapped[int] = mapped_column(ForeignKey("question.id"), nullable=False)


### PR DESCRIPTION
## Summary
- avoid duplicated questions when selecting from exam
- ensure unique (exam_id, question_id) pairs
- expose migration to create unique index for exam-question

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb7350ff4832999d20f54f41d0164