### PR TITLE
Fix default DB path usage

### DIFF
--- a/src/examgen/config.py
+++ b/src/examgen/config.py
@@ -26,7 +26,8 @@ class AppSettings:
                 data = json.load(f)
 
             if "data_db_path" not in data and "data_dir" in data:
-                data["data_db_path"] = str(Path(data["data_dir"]) / "examgen.db")
+                data_dir = Path(data["data_dir"])
+                data["data_db_path"] = str(data_dir / DEFAULT_DB.name)
 
             valid = {f.name for f in fields(cls)}
             clean = {k: v for k, v in data.items() if k in valid}

--- a/src/examgen/core/database.py
+++ b/src/examgen/core/database.py
@@ -14,9 +14,13 @@ from examgen.core.models import Base, _create_examiner_tables
 
 
 LEGACY_DB = Path("examgen.db")
+LEGACY_DOCS_DB = Path.home() / "Documents" / "examgen.db"
 
 if LEGACY_DB.exists() and not DEFAULT_DB.exists():
     LEGACY_DB.rename(DEFAULT_DB)
+
+if LEGACY_DOCS_DB.exists() and DEFAULT_DB.exists():
+    LEGACY_DOCS_DB.unlink()
 
 if not DEFAULT_DB.exists():
     DEFAULT_DB.touch()

--- a/src/examgen/core/migrations/add_section.py
+++ b/src/examgen/core/migrations/add_section.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
-from sqlalchemy import create_engine
-
 from sqlalchemy.exc import OperationalError
 
-from examgen.config import AppSettings
+from examgen.core.database import get_engine
 
 requires: set[str] = {"question"}
 provides: set[str] = set()
@@ -13,11 +10,7 @@ provides: set[str] = set()
 
 def run() -> None:
     """Ensure ``section`` column exists in ``question`` table."""
-    db_path = Path(
-        AppSettings.load().data_db_path
-        or Path.home() / "Documents" / "examgen.db"
-    )
-    eng = create_engine(f"sqlite:///{db_path}", future=True)
+    eng = get_engine()
     with eng.begin() as conn:
         cols = {
             row[1]

--- a/src/examgen/core/migrations/create_schema.py
+++ b/src/examgen/core/migrations/create_schema.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
-
-from sqlalchemy import create_engine
-
-from examgen.config import AppSettings
+from examgen.core.database import get_engine
 from examgen.core.models import Base
 
 # No prerequisites: this migration creates the initial schema
@@ -15,9 +11,5 @@ provides: set[str] = set(Base.metadata.tables)
 
 def run() -> None:
     """Create all tables if they don't exist."""
-    db_path = Path(
-        AppSettings.load().data_db_path
-        or Path.home() / "Documents" / "examgen.db"
-    )
-    eng = create_engine(f"sqlite:///{db_path}", future=True)
+    eng = get_engine()
     Base.metadata.create_all(eng)

--- a/src/examgen/core/migrations/fix_attempt_fk.py
+++ b/src/examgen/core/migrations/fix_attempt_fk.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import sqlalchemy as sa
 from sqlalchemy import (
     Column,
@@ -10,16 +8,13 @@ from sqlalchemy import (
     MetaData,
     String,
     Table,
-    create_engine,
 )
-
-from examgen.config import AppSettings
+from examgen.core.database import get_engine
 
 
 def run() -> None:
     """Fix attempt_question FK pointing to attempt.id."""
-    db_path = Path(AppSettings.load().data_db_path or Path.home() / "Documents" / "examgen.db")
-    eng = create_engine(f"sqlite:///{db_path}", future=True)
+    eng = get_engine()
     meta = MetaData()
     try:
         meta.reflect(bind=eng, resolve_fks=False)
@@ -50,7 +45,9 @@ def run() -> None:
 
     with eng.begin() as conn:
         print("Migrando FK de attempt_question ...")
-        conn.exec_driver_sql("ALTER TABLE attempt_question RENAME TO attempt_question_old;")
+        conn.exec_driver_sql(
+            "ALTER TABLE attempt_question RENAME TO attempt_question_old;"
+        )
 
         meta2 = MetaData()
         Table(
@@ -91,4 +88,3 @@ def run() -> None:
 
         conn.exec_driver_sql("DROP TABLE attempt_question_old;")
         print("Migración completada.")
-

--- a/src/examgen/core/models.py
+++ b/src/examgen/core/models.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 """
-ExamGen – ORM models (single‑table inheritance con columna `type` + JSON `meta`).
-Ejecuta:       python -m examgen.models
-para crear / actualizar examgen.db en la raíz del proyecto.
+ExamGen – ORM models (single-table inheritance con columna ``type`` y ``meta``.
+Ejecuta ``python -m examgen.models`` para crear o actualizar la base de datos
+predeterminada.
 """
 
 # ruff: noqa: E402
@@ -34,6 +34,7 @@ from sqlalchemy.orm import (
     mapped_column,
     relationship,
 )
+from examgen.config import DEFAULT_DB
 
 
 class SelectorTypeEnum(str, _Enum):
@@ -267,11 +268,14 @@ def _create_examiner_tables(engine: Engine) -> None:
 # -----------------------------------------------------------------------------
 
 
-def get_engine(db_path: str | Path = "examgen.db"):
+
+def get_engine(db_path: str | Path = DEFAULT_DB) -> Engine:
+    """Create an engine bound to ``db_path``."""
     return create_engine(f"sqlite:///{db_path}", echo=False, future=True)
 
 
-def init_db(db_path: str | Path = "examgen.db") -> None:
+def init_db(db_path: str | Path = DEFAULT_DB) -> None:
+    """Initialise database at ``db_path`` applying migrations."""
     from examgen.core.database import set_engine, get_engine, init_db as _init
 
     set_engine(Path(db_path))

--- a/src/examgen/core/services/importer.py
+++ b/src/examgen/core/services/importer.py
@@ -1,13 +1,21 @@
-import csv, json
-from examgen.core import models as m
+import csv
+import json
 
-def import_csv(path: str, db_path: str = "examgen.db") -> None:
+from examgen.core import models as m
+from examgen.config import DEFAULT_DB
+
+
+def import_csv(path: str, db_path: str = DEFAULT_DB) -> None:
     engine = m.get_engine(db_path)
     session = m.Session(engine)
-    with open(path, newline='', encoding="utf-8") as f:
+    with open(path, newline="", encoding="utf-8") as f:
         for row in csv.DictReader(f):
-            subj = session.query(m.Subject).filter_by(name=row["subject"]).first() \
-                   or m.Subject(name=row["subject"])
+            subj = (
+                session.query(m.Subject)
+                .filter_by(name=row["subject"])
+                .first()
+                or m.Subject(name=row["subject"])
+            )
             q = m.MCQQuestion(
                 prompt=row["prompt"],
                 explanation=row.get("explanation"),

--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -12,10 +12,10 @@ from examgen.core.database import (
     run_migrations,
     set_engine,
 )
-from examgen.config import settings
+from examgen.config import settings, DEFAULT_DB
 
 
-db_path = Path(settings.data_db_path or Path.home() / "Documents" / "examgen.db")
+db_path = Path(settings.data_db_path or DEFAULT_DB)
 db_path.parent.mkdir(parents=True, exist_ok=True)
 set_engine(db_path)
 run_migrations()

--- a/src/examgen/gui/dialogs/question_dialog.py
+++ b/src/examgen/gui/dialogs/question_dialog.py
@@ -30,13 +30,14 @@ from PySide6.QtWidgets import (
     QLineEdit,
 )
 
+from examgen.config import DEFAULT_DB
 from examgen.core import models as m
 from examgen.core.database import SessionLocal
 from examgen.core.services.exam_service import ExamConfig
 from examgen.core.models import SelectorTypeEnum
 from sqlalchemy.orm import Session, joinedload, selectinload
 
-DB_PATH = Path("examgen.db")
+DB_PATH = Path(DEFAULT_DB)
 MAX_CHARS = 3000
 MIN_ROWS = 3
 

--- a/src/examgen/gui/dialogs/settings_dialog.py
+++ b/src/examgen/gui/dialogs/settings_dialog.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from examgen.config import AppSettings
+from examgen.config import AppSettings, DEFAULT_DB
 from examgen.core.database import set_engine
 
 
@@ -66,7 +66,7 @@ class SettingsDialog(QDialog):
         )
         if not path:
             return
-        self.le_db.setText(str(Path(path) / "examgen.db"))
+        self.le_db.setText(str(Path(path) / DEFAULT_DB.name))
 
     def accept(self) -> None:  # type: ignore[override]
         self.settings.theme = self.cb_theme.currentText()

--- a/src/examgen/gui/pages/settings_page.py
+++ b/src/examgen/gui/pages/settings_page.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from examgen.config import AppSettings
+from examgen.config import AppSettings, DEFAULT_DB
 from examgen.core.database import set_engine
 
 if TYPE_CHECKING:  # pragma: no cover - circular imports only for type hints
@@ -74,7 +74,7 @@ class SettingsPage(QWidget):
         )
         if not path:
             return
-        self.le_db.setText(str(Path(path) / "examgen.db"))
+        self.le_db.setText(str(Path(path) / DEFAULT_DB.name))
 
     def save_settings(self) -> None:
         self.settings.theme = self.cb_theme.currentText()

--- a/src/examgen/gui/windows/main_window.py
+++ b/src/examgen/gui/windows/main_window.py
@@ -16,9 +16,8 @@ import os
 env_path = Path(__file__).resolve().parents[3] / ".env"
 load_dotenv(env_path)
 
-from examgen.config import settings
-DB_HOME = Path.home() / "Documents" / "examgen.db"
-DB_PATH = Path(settings.data_db_path or DB_HOME)
+from examgen.config import settings, DEFAULT_DB
+DB_PATH = Path(settings.data_db_path or DEFAULT_DB)
 LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING").upper()
 THEME_MAP = {"dark": "Oscuro", "light": "Claro"}
 THEME = THEME_MAP.get(settings.theme, "Oscuro")


### PR DESCRIPTION
## Summary
- unify default database handling using `DEFAULT_DB`
- remove legacy `examgen.db` from user Documents if present
- clean up migrations to reuse current engine
- adjust GUI and importer to new default path

## Testing
- `flake8 src/ tests/` *(fails: E501 on existing lines)*
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684eba8e8df48329bc25e6648bd4c9b5