### PR TITLE
JSON-line logger con métricas de latencia y estado (EXG-DEV)

### DIFF
--- a/src/examgen/utils/debug.py
+++ b/src/examgen/utils/debug.py
@@ -1,7 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import sys
+import time
+
 from examgen.config import settings
+
+_prev_render_ts: float | None = None
+
+
+def jlog(evt: str, **extra: object) -> None:
+    """Emit a JSON line with *evt* and any *extra* fields."""
+    if not settings.debug_mode:
+        return
+    now = datetime.now().isoformat(timespec="milliseconds")
+    rec = {"ts": now, "evt": evt, **extra}
+    print(json.dumps(rec, ensure_ascii=False), file=sys.stderr)
 
 
 def log(msg: str) -> None:
-    """Print *msg* when debug mode is active."""
-    if getattr(settings, "debug_mode", False):
-        print(f"[DEBUG] {msg}")
+    """Compatibility wrapper for plain text logs."""
+    jlog("log", message=msg)
+
+
+def mark_render_start() -> None:
+    """Store the current time to compute render latency."""
+    global _prev_render_ts
+    _prev_render_ts = time.perf_counter()
+
+
+def render_elapsed() -> int:
+    """Return elapsed milliseconds since ``mark_render_start``."""
+    start = _prev_render_ts or time.perf_counter()
+    return int((time.perf_counter() - start) * 1000)

--- a/src/examgen/utils/logger.py
+++ b/src/examgen/utils/logger.py
@@ -25,6 +25,11 @@ def set_logging() -> None:
     console.setFormatter(fmt)
     root.addHandler(console)
 
+    debug_h = logging.StreamHandler(sys.stderr)
+    debug_h.setLevel(logging.DEBUG)
+    debug_h.setFormatter(fmt)
+    root.addHandler(debug_h)
+
     if settings.debug_mode:
         log_dir = Path(user_log_dir("ExamGen"))
         log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- implement JSON-line debug logger with timing helpers
- log key events in `ExamPage`
- stream debug logs to stderr and optionally file

## Testing
- `flake8 src/examgen/utils/debug.py src/examgen/utils/logger.py src/examgen/gui/pages/exam_page.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec056a90c83298ac828aafd651e7f