### PR TITLE
Implement selectable DB folder and file-only logging

### DIFF
--- a/src/examgen/config.py
+++ b/src/examgen/config.py
@@ -3,20 +3,25 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict, fields
 import json
 from pathlib import Path
-from platformdirs import user_config_dir
+from platformdirs import user_config_dir, user_log_dir
 
 CFG_DIR = Path(user_config_dir("ExamGen"))
 CFG_DIR.mkdir(parents=True, exist_ok=True)
 
-# Base de datos inicial (vacía) si no existe ninguna
+db_folder: str | None = None  # carpeta elegida por usuario
 DEFAULT_DB = CFG_DIR / "examgen_initial_empty.db"
+
+
+def db_path() -> Path:
+    return Path(db_folder) / "examgen.db" if db_folder else DEFAULT_DB
+
 SETTINGS_FILE = CFG_DIR / "settings.json"
 
 
 @dataclass
 class AppSettings:
     theme: str = "dark"
-    data_db_path: str | None = None
+    db_folder: str | None = None
     debug_mode: bool = False
 
     @classmethod
@@ -25,9 +30,11 @@ class AppSettings:
             with SETTINGS_FILE.open(encoding="utf-8") as f:
                 data = json.load(f)
 
-            if "data_db_path" not in data and "data_dir" in data:
-                data_dir = Path(data["data_dir"])
-                data["data_db_path"] = str(data_dir / DEFAULT_DB.name)
+            if "db_folder" not in data:
+                if "data_db_path" in data:
+                    data["db_folder"] = str(Path(data["data_db_path"]).parent)
+                elif "data_dir" in data:
+                    data["db_folder"] = data["data_dir"]
 
             valid = {f.name for f in fields(cls)}
             clean = {k: v for k, v in data.items() if k in valid}
@@ -40,3 +47,4 @@ class AppSettings:
 
 
 settings = AppSettings.load()
+db_folder = settings.db_folder

--- a/src/examgen/core/database.py
+++ b/src/examgen/core/database.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
-from examgen.config import DEFAULT_DB
+from examgen.config import db_path
 from examgen.utils.debug import log
 
 from examgen.core.models import Base, _create_examiner_tables
@@ -22,20 +22,20 @@ if LEGACY_DB.exists() and not DEFAULT_DB.exists():
 if LEGACY_DOCS_DB.exists() and DEFAULT_DB.exists():
     LEGACY_DOCS_DB.unlink()
 
-if not DEFAULT_DB.exists():
-    DEFAULT_DB.touch()
-
-engine = create_engine(f"sqlite:///{DEFAULT_DB}", future=True)
+DB_FILE = db_path()
+DB_FILE.parent.mkdir(parents=True, exist_ok=True)
+DB_FILE.touch(exist_ok=True)
+engine = create_engine(f"sqlite:///{DB_FILE}", future=True)
 SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
 
 _engine: Engine | None = engine
 
 
-def set_engine(db_path: Path | None = None) -> None:
+def set_engine(db_file: Path | None = None) -> None:
     """Create and register a new engine bound to ``db_path``."""
     global _engine
 
-    path = db_path or DEFAULT_DB
+    path = db_file or db_path()
 
     if not path.exists():
         if LEGACY_DB.exists():

--- a/src/examgen/gui/app.py
+++ b/src/examgen/gui/app.py
@@ -12,14 +12,14 @@ from examgen.core.database import (
     run_migrations,
     set_engine,
 )
-from examgen.config import settings, DEFAULT_DB
+from examgen.config import settings, db_path
 
 
-db_path = Path(settings.data_db_path or DEFAULT_DB)
-db_path.parent.mkdir(parents=True, exist_ok=True)
-set_engine(db_path)
+db_file = db_path()
+db_file.parent.mkdir(parents=True, exist_ok=True)
+set_engine(db_file)
 run_migrations()
-if db_path.exists() or settings.data_db_path is None:
+if db_file.exists() or settings.db_folder is None:
     init_db(get_engine())
 
 

--- a/src/examgen/gui/dialogs/settings_dialog.py
+++ b/src/examgen/gui/dialogs/settings_dialog.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from examgen.config import AppSettings, DEFAULT_DB
+from examgen.config import AppSettings, db_path
 from examgen.core.database import set_engine
 
 
@@ -34,7 +34,7 @@ class SettingsDialog(QDialog):
         self.cb_theme.setCurrentText(settings.theme)
 
         # --- Campo BD ---
-        self.le_db = QLineEdit(settings.data_db_path or "")
+        self.le_db = QLineEdit(settings.db_folder or "")
         self.le_db.setReadOnly(True)
         btn_choose = QPushButton("Elegir…", clicked=self._choose_db)
 
@@ -54,24 +54,18 @@ class SettingsDialog(QDialog):
         root.addWidget(buttons)
 
     def _choose_db(self) -> None:
-        start_dir = (
-            Path(self.settings.data_db_path).parent
-            if self.settings.data_db_path
-            else Path(QStandardPaths.writableLocation(QStandardPaths.DocumentsLocation))
-        )
         path = QFileDialog.getExistingDirectory(
-            self,
-            "Seleccionar carpeta de datos",
-            str(start_dir),
+            self, "Seleccionar carpeta de datos"
         )
-        if not path:
-            return
-        self.le_db.setText(str(Path(path) / DEFAULT_DB.name))
+        if path:
+            self.le_db.setText(path)
 
     def accept(self) -> None:  # type: ignore[override]
         self.settings.theme = self.cb_theme.currentText()
-        self.settings.data_db_path = self.le_db.text() or None
+        import examgen.config as cfg
+        self.settings.db_folder = self.le_db.text() or None
+        cfg.db_folder = self.settings.db_folder
         self.settings.save()
-        if self.settings.data_db_path:
-            set_engine(Path(self.settings.data_db_path))
+        if self.settings.db_folder:
+            set_engine(db_path())
         super().accept()

--- a/src/examgen/gui/windows/main_window.py
+++ b/src/examgen/gui/windows/main_window.py
@@ -16,8 +16,7 @@ import os
 env_path = Path(__file__).resolve().parents[3] / ".env"
 load_dotenv(env_path)
 
-from examgen.config import settings, DEFAULT_DB
-DB_PATH = Path(settings.data_db_path or DEFAULT_DB)
+from examgen.config import settings, db_path
 LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING").upper()
 THEME_MAP = {"dark": "Oscuro", "light": "Claro"}
 THEME = THEME_MAP.get(settings.theme, "Oscuro")
@@ -25,7 +24,7 @@ THEME = THEME_MAP.get(settings.theme, "Oscuro")
 logger = logging.getLogger(__name__)
 if LOG_LEVEL == "DEBUG":
     logger.debug("Loaded .env from %s", env_path)
-    logger.debug("DB path: %s", DB_PATH)
+    logger.debug("DB path: %s", db_path())
     logger.debug("Theme  : %s", THEME)
 
 try:
@@ -78,7 +77,7 @@ class MainWindow(QMainWindow):
         # Menú y barra de estado
         self._create_menu_bar()
         self._create_status_bar()
-        self._set_app_actions_enabled(bool(self.settings.data_db_path))
+        self._set_app_actions_enabled(bool(self.settings.db_folder))
 
     # --------------------------------------------------------------------- #
     #  Menú                                                                  #
@@ -233,7 +232,7 @@ class MainWindow(QMainWindow):
     #  Diálogo de pregunta                                                  #
     # --------------------------------------------------------------------- #
     def _open_question_dialog(self) -> None:
-        QuestionDialog(self, db_path=DB_PATH).exec()
+        QuestionDialog(self, db_path=db_path()).exec()
 
     def _show_questions(self) -> None:
         self._show_page("questions")
@@ -246,7 +245,7 @@ class MainWindow(QMainWindow):
 #  Entry-point                                                              #
 # ------------------------------------------------------------------------- #
 def main() -> None:
-    m.init_db(DB_PATH)  # crea BD si no existe
+    m.init_db(db_path())  # crea BD si no existe
 
     app = QApplication(sys.argv)
     apply_app_styles(app)

--- a/src/examgen/utils/logger.py
+++ b/src/examgen/utils/logger.py
@@ -13,33 +13,17 @@ def set_logging() -> None:
     from examgen.config import settings
 
     root = logging.getLogger()
-    while root.handlers:
-        root.removeHandler(root.handlers[0])
-
-    fmt = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-    )
-
-    console = logging.StreamHandler(sys.stdout)
-    console.setLevel(logging.INFO)
-    console.setFormatter(fmt)
-    root.addHandler(console)
-
-    debug_h = logging.StreamHandler(sys.stderr)
-    debug_h.setLevel(logging.DEBUG)
-    debug_h.setFormatter(fmt)
-    root.addHandler(debug_h)
+    root.handlers.clear()
 
     if settings.debug_mode:
         log_dir = Path(user_log_dir("ExamGen"))
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_file = log_dir / f"examgen_{datetime.now():%Y%m%d_%H%M}.log"
         file_h = RotatingFileHandler(
-            log_file, maxBytes=1_000_000, backupCount=3
+            log_dir / f"examgen_{datetime.now():%Y%m%d_%H%M}.log",
+            maxBytes=1_000_000,
+            backupCount=3,
         )
         file_h.setLevel(logging.DEBUG)
-        file_h.setFormatter(fmt)
         root.addHandler(file_h)
 
-    root.setLevel(logging.DEBUG if settings.debug_mode else logging.INFO)
-    logging.info("Logging inicializado (debug=%s)", settings.debug_mode)
+    root.setLevel(logging.DEBUG if settings.debug_mode else logging.CRITICAL)


### PR DESCRIPTION
## Summary
- add `db_folder` setting and helper `db_path`
- adjust database setup to use `db_path`
- update settings page and dialog to pick database folder
- rework logging so debug logs go only to rotating file

## Testing
- `flake8 src/examgen/core/database.py src/examgen/config.py src/examgen/utils/logger.py | head`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684ec66515388329b7ffe3e0961933ec