### PR TITLE
Fix debug logging behaviour

### DIFF
--- a/src/examgen/utils/debug.py
+++ b/src/examgen/utils/debug.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
-import sys
+import logging
 import time
 
 from examgen.config import settings
@@ -16,7 +16,9 @@ def jlog(evt: str, **extra: object) -> None:
         return
     now = datetime.now().isoformat(timespec="milliseconds")
     rec = {"ts": now, "evt": evt, **extra}
-    print(json.dumps(rec, ensure_ascii=False), file=sys.stderr)
+    logging.getLogger("examgen").debug(
+        json.dumps(rec, ensure_ascii=False)
+    )
 
 
 def log(msg: str) -> None:

--- a/src/examgen/utils/logger.py
+++ b/src/examgen/utils/logger.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import logging
-import sys
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from platformdirs import user_log_dir
+
+
+class _Null(logging.Handler):
+    """Handler that discards all records."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        """Do nothing."""
+        pass
 
 
 def set_logging() -> None:
@@ -22,8 +29,11 @@ def set_logging() -> None:
             log_dir / f"examgen_{datetime.now():%Y%m%d_%H%M}.log",
             maxBytes=1_000_000,
             backupCount=3,
+            encoding="utf-8",
         )
         file_h.setLevel(logging.DEBUG)
         root.addHandler(file_h)
-
-    root.setLevel(logging.DEBUG if settings.debug_mode else logging.CRITICAL)
+        root.setLevel(logging.DEBUG)
+    else:
+        root.addHandler(_Null())
+        root.setLevel(logging.CRITICAL)


### PR DESCRIPTION
## Summary
- route debug logs through `logging` instead of `print`
- silence root logger when debug mode is off

## Testing
- `flake8 src/ tests/` *(fails: many unrelated style errors)*
- `pytest -q` *(fails: ImportError: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ece383fe48329a95465a3e0f099ad