### PR TITLE
feat(debug): structured metrics logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ pydantic>=2.6
 faker>=25.2
 flake8>=7.0
 platformdirs>=4.0
+psutil>=5.9

--- a/src/examgen/gui/pages/exam_page.py
+++ b/src/examgen/gui/pages/exam_page.py
@@ -41,8 +41,9 @@ from examgen.gui.dialogs.results_dialog import ResultsDialog
 from examgen.utils.debug import (
     jlog,
     mark_render_start,
-    render_elapsed,
+    render_elapsed_ms,
 )
+import psutil
 
 
 @dataclass(slots=True)
@@ -267,9 +268,12 @@ class ExamPage(QWidget):
                 )
                 return
         self._actualizar_estado_botones()
+        btn_text = ""
+        if hasattr(sender, "text"):
+            btn_text = str(sender.text())[:40]
         jlog(
             "toggle",
-            btn=getattr(sender, "text", lambda: "")(),
+            btn=btn_text,
             checked=getattr(sender, "isChecked", lambda: False)(),
             sel=self._selecciones_actuales(),
             needed=self.num_correct,
@@ -465,7 +469,9 @@ class ExamPage(QWidget):
             "layout",
             scroll=self.scroll.height(),
             opts_panel=self.opts_panel.height(),
-            render_ms=render_elapsed(),
+            render_ms=render_elapsed_ms(),
+            cpu_pct=psutil.cpu_percent(interval=None),
+            mem_mb=int(psutil.Process().memory_full_info().uss / 1e6),
         )
 
     def _toggle_pause(self) -> None:

--- a/src/examgen/utils/logger.py
+++ b/src/examgen/utils/logger.py
@@ -7,19 +7,11 @@ from pathlib import Path
 from platformdirs import user_log_dir
 
 
-class _Null(logging.Handler):
-    """Handler that discards all records."""
-
-    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
-        """Do nothing."""
-        pass
-
-
 def set_logging() -> None:
     """Configure root logger according to ``settings.debug_mode``."""
     from examgen.config import settings
 
-    root = logging.getLogger()
+    root = logging.getLogger("examgen")
     root.handlers.clear()
 
     if settings.debug_mode:
@@ -35,5 +27,4 @@ def set_logging() -> None:
         root.addHandler(file_h)
         root.setLevel(logging.DEBUG)
     else:
-        root.addHandler(_Null())
         root.setLevel(logging.CRITICAL)


### PR DESCRIPTION
## Summary
- silence console logging by default
- add session-based JSON logging helper
- log CPU and memory metrics on layout
- capture button state in option toggles
- include psutil in requirements

## Testing
- `flake8 src/examgen/utils/debug.py src/examgen/utils/logger.py src/examgen/gui/pages/exam_page.py`
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ed3564eb08329b0d7132278619257