### PR TITLE
Add psutil dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ black>=24.4
 mypy>=1.10
 pydantic>=2.6
 faker>=25.2
+psutil>=5.9


### PR DESCRIPTION
## Summary
- add `psutil` to requirements to fix missing dependency error

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684ede58e43883299bceccfc893b8c93