### PR TITLE
feat(EXG-6): binding a BD y dominio (reutilización) sin tocar tablas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Modo Web Local — variables de entorno
+EXAMGEN_DB_URL=sqlite:///ABSOLUTE/PATH/TO/examgen.db
+EXAMGEN_HOST=127.0.0.1
+EXAMGEN_PORT=5000
+EXAMGEN_DEBUG=1

--- a/examgen_web/app.py
+++ b/examgen_web/app.py
@@ -1,13 +1,25 @@
 import os
+import sys
+from pathlib import Path
 from . import create_app
+
+# Asegura que 'src/' esté en sys.path para importar 'examgen' en modo editable
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if SRC.exists():
+    src_path = str(SRC)
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
 
 # Instancia global para test clients y flask CLI
 app = create_app()
+
 
 def _get_bool(env_value: str | None, default: bool = False) -> bool:
     if env_value is None:
         return default
     return env_value.lower() in ("1", "true", "yes", "on")
+
 
 if __name__ == "__main__":
     host = os.getenv("EXAMGEN_HOST", "127.0.0.1")

--- a/examgen_web/infra/config.py
+++ b/examgen_web/infra/config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+# Carga .env si existe (no falla si no está)
+try:
+    from dotenv import load_dotenv  # type: ignore
+
+    load_dotenv()
+except Exception:
+    pass
+
+# platformdirs es opcional; si no está, se usa ~/.examgen
+try:
+    from platformdirs import user_data_dir  # type: ignore
+except Exception:
+    user_data_dir = None  # type: ignore
+
+APP_NAME = "ExamGen"
+
+
+def _default_db_path() -> Path:
+    if user_data_dir:
+        base = Path(user_data_dir(APP_NAME))
+    else:
+        base = Path.home() / f".{APP_NAME.lower()}"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "examgen.db"
+
+
+def get_db_url() -> str:
+    url = os.getenv("EXAMGEN_DB_URL", "").strip()
+    if url:
+        return url
+    # Por defecto, SQLite en carpeta de datos local
+    return f"sqlite:///{_default_db_path().as_posix()}"
+
+
+def db_file_exists(db_url: str) -> bool:
+    # Solo es determinístico para SQLite
+    if db_url.startswith("sqlite:///"):
+        path = db_url.replace("sqlite:///", "", 1)
+        return Path(path).exists()
+    # Para otros motores, asumimos que existe (se validará con ping)
+    return True
+
+
+@dataclass(frozen=True)
+class Settings:
+    db_url: str
+
+
+def load_settings() -> Settings:
+    return Settings(db_url=get_db_url())

--- a/examgen_web/infra/db.py
+++ b/examgen_web/infra/db.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from contextlib import contextmanager
+from typing import Generator, Any, Optional
+
+from sqlalchemy import create_engine, text  # type: ignore
+from sqlalchemy.orm import sessionmaker  # type: ignore
+
+from .config import load_settings
+
+# Intento de reutilizar la sesión del dominio
+try:
+    # Debe existir algo como: examgen/data/session.py con get_session()
+    from examgen.data.session import get_session as domain_get_session  # type: ignore[attr-defined]
+except Exception:
+    domain_get_session = None  # type: ignore
+
+_settings = load_settings()
+
+# Fallback interno (no crea tablas)
+_engine = None
+_SessionLocal: Optional[sessionmaker] = None
+
+
+def _ensure_fallback_sessionmaker():
+    global _engine, _SessionLocal
+    if _SessionLocal is None:
+        connect_args = {}
+        if _settings.db_url.startswith("sqlite:///"):
+            # Permitir acceso desde hilos del servidor dev
+            connect_args = {"check_same_thread": False}
+        _engine = create_engine(
+            _settings.db_url, future=True, connect_args=connect_args
+        )
+        _SessionLocal = sessionmaker(
+            bind=_engine, autoflush=False, autocommit=False, future=True
+        )
+
+
+@contextmanager
+def get_session() -> Generator[Any, None, None]:
+    """
+    Devuelve una sesión de BD.
+    - Si el dominio expone get_session(), la usamos.
+    - Si no, usamos un sessionmaker local (fallback), sin crear tablas.
+    """
+    if domain_get_session:
+        with domain_get_session() as s:  # type: ignore[misc]
+            yield s
+        return
+
+    _ensure_fallback_sessionmaker()
+    assert _SessionLocal is not None
+    s = _SessionLocal()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def ping() -> dict:
+    """
+    Verifica conectividad de BD ejecutando 'SELECT 1'.
+    """
+    try:
+        with get_session() as s:
+            s.execute(text("SELECT 1"))
+        return {"status": "ok"}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}

--- a/examgen_web/infra/services.py
+++ b/examgen_web/infra/services.py
@@ -1,0 +1,34 @@
+"""
+Facade de servicios de dominio para ser usado por la capa web.
+No implementa lógica de negocio: solo importa (si existen) y expone factories.
+"""
+
+from typing import Any
+
+# Por ahora, solo preparamos los imports; EXG-6.3 usará estas entradas.
+try:
+    from examgen.domain.services import ExamService, SectionService, QuestionService  # type: ignore
+except Exception:
+    ExamService = None  # type: ignore
+    SectionService = None  # type: ignore
+    QuestionService = None  # type: ignore
+
+
+def get_exam_service(session: Any):
+    if ExamService is None:
+        raise RuntimeError(
+            "ExamService no disponible. Asegura que src/examgen/domain/services.py existe."
+        )
+    return ExamService(session)
+
+
+def get_section_service(session: Any):
+    if SectionService is None:
+        raise RuntimeError("SectionService no disponible.")
+    return SectionService(session)
+
+
+def get_question_service(session: Any):
+    if QuestionService is None:
+        raise RuntimeError("QuestionService no disponible.")
+    return QuestionService(session)

--- a/examgen_web/routes/health.py
+++ b/examgen_web/routes/health.py
@@ -1,13 +1,25 @@
 from flask import Blueprint, jsonify
+from examgen_web.infra.config import load_settings, db_file_exists
+from examgen_web.infra import db as dbi
 
 health_bp = Blueprint("health", __name__)
 
 
 @health_bp.get("/health")
 def health():
-    return jsonify({
-        "status": "ok",
-        "app": "ExamGen Web",
-        "version": "0.1.0",
-        "mode": "local"
-    }), 200
+    settings = load_settings()
+    exists = db_file_exists(settings.db_url)
+    db_probe = {"status": "missing"} if not exists else dbi.ping()
+
+    return (
+        jsonify(
+            {
+                "status": "ok",
+                "app": "ExamGen Web",
+                "version": "0.1.0",
+                "mode": "local",
+                "db": {"url": settings.db_url, "exists": exists, **db_probe},
+            }
+        ),
+        200,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ version = "0.1.0"
 dependencies = [
     "flask>=3.0,<4",
     "jinja2>=3.1,<4",
+    "sqlalchemy>=2.0",
+    "platformdirs>=4.0",
+    "python-dotenv>=1.0",
 ]
 
 [project.scripts]

--- a/scripts/backup_db.py
+++ b/scripts/backup_db.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402
+import sys
+import shutil
+import datetime
+from pathlib import Path
+
+# Permite ejecutar sin instalar el paquete
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if SRC.exists():
+    sys.path.insert(0, str(SRC))
+if ROOT.exists():
+    sys.path.insert(0, str(ROOT))
+
+from examgen_web.infra.config import get_db_url  # type: ignore
+
+
+def main(dst_dir: str | None = None) -> int:
+    url = get_db_url()
+    if not url.startswith("sqlite:///"):
+        print("[!] Solo se soporta backup para SQLite en este script.")
+        return 1
+
+    db_path = Path(url.replace("sqlite:///", "", 1))
+    if not db_path.exists():
+        print(f"[!] Fichero de BD no encontrado: {db_path}")
+        return 2
+
+    dst = Path(dst_dir or (ROOT / "backups"))
+    dst.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+    out = dst / f"examgen-{ts}.db"
+    shutil.copy2(db_path, out)
+    print(f"[ok] Backup creado: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else None))

--- a/tests/test_db_binding.py
+++ b/tests/test_db_binding.py
@@ -1,0 +1,13 @@
+from examgen_web.app import app as flask_app
+
+
+def test_health_db_keys():
+    flask_app.testing = True
+    with flask_app.test_client() as c:
+        r = c.get("/health")
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "db" in data
+        assert "url" in data["db"]
+        assert "exists" in data["db"]
+        assert "status" in data["db"]


### PR DESCRIPTION
## Summary
- add infrastructure layer to manage DB URL and sessions without altering schema
- expose domain services and report DB status via /health
- provide backup script, env example, and dependency declarations

## Testing
- `ruff check examgen_web/infra/config.py examgen_web/infra/db.py examgen_web/infra/services.py examgen_web/app.py examgen_web/routes/health.py scripts/backup_db.py tests/test_db_binding.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`
- `python scripts/backup_db.py` *(fails: Fichero de BD no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_689f17e929248329b57ef18a7d873eda