### PR TITLE
feat(EXG-6): CRUD de Exámenes (list/create/detail) en capa web con fallback seguro

### DIFF
--- a/examgen_web/__init__.py
+++ b/examgen_web/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from .routes.home import home_bp
 from .routes.health import health_bp
+from .routes.exams import exams_bp  # <- NUEVO
 
 
 def create_app() -> Flask:
@@ -12,4 +13,5 @@ def create_app() -> Flask:
     # Blueprints
     app.register_blueprint(home_bp)
     app.register_blueprint(health_bp)
+    app.register_blueprint(exams_bp)  # <- NUEVO
     return app

--- a/examgen_web/routes/exams.py
+++ b/examgen_web/routes/exams.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from flask import Blueprint, render_template, request, redirect, url_for, abort
+from sqlalchemy import text  # type: ignore
+
+from examgen_web.infra.db import get_session
+from examgen_web.infra import services as domain_services
+
+exams_bp = Blueprint("exams", __name__)
+
+
+# ---------- Utilidades ----------
+
+def _domain_available() -> bool:
+    # domain_services.ExamService es None si el import falló en EXG-6.2
+    return getattr(domain_services, "ExamService", None) is not None
+
+
+def _to_exam_dict(obj: Any) -> Dict[str, Any]:
+    """
+    Normaliza entidades de dominio o filas a un dict de vista.
+    Se toleran atributos/columnas ausentes.
+    """
+    get = lambda k, default=None: getattr(obj, k, obj.get(k, default)) if isinstance(obj, dict) else getattr(obj, k, default)
+    return {
+        "id": get("id"),
+        "title": get("title"),
+        "description": get("description"),
+        "language": get("language"),
+        "created_at": get("created_at"),
+        "updated_at": get("updated_at"),
+    }
+
+
+# ---- Fallback SQL (sin crear tablas) ----
+
+def _exam_columns(session) -> List[str]:
+    cols: List[str] = []
+    try:
+        res = session.execute(text("PRAGMA table_info(exam)"))
+        cols = [row[1] for row in res.fetchall()]  # row[1] = name
+    except Exception:
+        cols = []
+    return cols
+
+
+def _list_exams_fallback(session) -> List[Dict[str, Any]]:
+    cols = _exam_columns(session)
+    if not cols:
+        return []
+    order = "created_at DESC" if "created_at" in cols else "id DESC" if "id" in cols else None
+    sql = "SELECT * FROM exam" + (f" ORDER BY {order}" if order else "")
+    rows = session.execute(text(sql)).mappings().all()
+    return [dict(r) for r in rows]
+
+
+def _get_exam_fallback(session, exam_id: int) -> Optional[Dict[str, Any]]:
+    cols = _exam_columns(session)
+    if not cols:
+        return None
+    row = session.execute(text("SELECT * FROM exam WHERE id = :id"), {"id": exam_id}).mappings().one_or_none()
+    return dict(row) if row else None
+
+
+def _insert_exam_fallback(session, title: str, description: str, language: Optional[str]) -> Optional[int]:
+    cols = set(_exam_columns(session))
+    if not cols:
+        # Tabla inexistente
+        return None
+
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    data: Dict[str, Any] = {}
+    # Solo seteamos columnas existentes para no romper esquema
+    if "title" in cols:
+        data["title"] = title
+    if "description" in cols:
+        data["description"] = description
+    if "language" in cols:
+        data["language"] = language or "es-ES"
+    if "created_at" in cols:
+        data["created_at"] = now
+    if "updated_at" in cols:
+        data["updated_at"] = now
+
+    if not data:
+        return None
+
+    keys = list(data.keys())
+    placeholders = [f":{k}" for k in keys]
+    sql = text(f"INSERT INTO exam ({', '.join(keys)}) VALUES ({', '.join(placeholders)})")
+    session.execute(sql, data)
+    session.commit()
+
+    # Intentar recuperar ID
+    if "id" in cols:
+        try:
+            rid = session.execute(text("SELECT last_insert_rowid()")).scalar()
+            if isinstance(rid, int):
+                return rid
+        except Exception:
+            pass
+        # Fallback: último por id
+        try:
+            rid = session.execute(text("SELECT id FROM exam ORDER BY id DESC LIMIT 1")).scalar()
+            if isinstance(rid, int):
+                return rid
+        except Exception:
+            pass
+    return None
+
+
+# ---------- Endpoints ----------
+
+
+@exams_bp.get("/exams")
+def list_exams():
+    with get_session() as s:
+        exams: List[Dict[str, Any]] = []
+        if _domain_available():
+            try:
+                svc = domain_services.get_exam_service(s)
+                # Suponemos contratos del dominio: .list_exams() -> lista de entidades
+                exams = [_to_exam_dict(e) for e in svc.list_exams()]  # type: ignore[attr-defined]
+            except Exception:
+                # Si el dominio no tiene esa API, caemos a fallback seguro
+                exams = _list_exams_fallback(s)
+        else:
+            exams = _list_exams_fallback(s)
+
+    return render_template("exams_list.html", exams=exams)
+
+
+@exams_bp.get("/exams/new")
+def new_exam():
+    return render_template(
+        "exam_form.html",
+        errors={},
+        form={"title": "", "description": "", "language": "es-ES"},
+    )
+
+
+@exams_bp.post("/exams")
+def create_exam():
+    title = (request.form.get("title") or "").strip()
+    description = (request.form.get("description") or "").strip()
+    language = (request.form.get("language") or "").strip() or None
+
+    errors: Dict[str, str] = {}
+    if not title:
+        errors["title"] = "El título es obligatorio."
+
+    if errors:
+        return (
+            render_template(
+                "exam_form.html",
+                errors=errors,
+                form={
+                    "title": title,
+                    "description": description,
+                    "language": language or "es-ES",
+                },
+            ),
+            400,
+        )
+
+    with get_session() as s:
+        # Ruta dominio si está disponible
+        if _domain_available():
+            try:
+                svc = domain_services.get_exam_service(s)
+                created = svc.create_exam(
+                    {
+                        "title": title,
+                        "description": description,
+                        "language": language or "es-ES",
+                    }
+                )  # type: ignore[attr-defined]
+                exam_id = getattr(created, "id", None)
+                if exam_id is None:
+                    # Si el dominio no devuelve ID, consultamos el último examen
+                    # (esto no crea tablas ni cambia esquema)
+                    rows = _list_exams_fallback(s)
+                    exam_id = rows[0]["id"] if rows and "id" in rows[0] else None
+            except Exception:
+                # Fallback seguro
+                exam_id = _insert_exam_fallback(s, title, description, language)
+        else:
+            exam_id = _insert_exam_fallback(s, title, description, language)
+
+    if isinstance(exam_id, int):
+        return redirect(url_for("exams.exam_detail", exam_id=exam_id))
+    # Si no hay ID disponible, volvemos al listado
+    return redirect(url_for("exams.list_exams"))
+
+
+@exams_bp.get("/exams/<int:exam_id>")
+def exam_detail(exam_id: int):
+    with get_session() as s:
+        exam: Optional[Dict[str, Any]] = None
+        if _domain_available():
+            try:
+                svc = domain_services.get_exam_service(s)
+                e = svc.get_exam(exam_id)  # type: ignore[attr-defined]
+                if e:
+                    exam = _to_exam_dict(e)
+            except Exception:
+                exam = _get_exam_fallback(s, exam_id)
+        else:
+            exam = _get_exam_fallback(s, exam_id)
+
+    if not exam:
+        abort(404)
+    # Nota: Secciones y preguntas llegarán en EXG-6.4
+    return render_template("exam_detail.html", exam=exam)

--- a/examgen_web/templates/exam_detail.html
+++ b/examgen_web/templates/exam_detail.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}{{ (exam.title or exam["title"]) ~ " · ExamGen" }}{% endblock %}
+{% block content %}
+<section class="card">
+  <header style="display:flex;justify-content:space-between;align-items:center;gap:1rem">
+    <div>
+      <h2 style="margin:0">{{ exam.title or exam["title"] }}</h2>
+      <p style="margin:.25rem 0;color:#475569">{{ exam.description or exam["description"] or "" }}</p>
+      <div class="badge">Idioma: {{ exam.language or exam["language"] or "—" }}</div>
+    </div>
+    <div class="actions">
+      <a class="btn secondary" href="{{ url_for('exams.list_exams') }}">Volver</a>
+      <a class="btn" href="/exams/{{ exam.id or exam['id'] }}/preview">Previsualizar</a>
+    </div>
+  </header>
+</section>
+
+<section class="card" style="margin-top:1rem">
+  <h3 style="margin-top:0">Secciones</h3>
+  <p style="color:#475569">La gestión de secciones y preguntas se añadirá en <strong>EXG‑6.4</strong>.</p>
+  <div class="actions">
+    <a class="btn disabled" aria-disabled="true" title="Disponible en EXG‑6.4">+ Añadir sección</a>
+  </div>
+</section>
+{% endblock %}

--- a/examgen_web/templates/exam_form.html
+++ b/examgen_web/templates/exam_form.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Nuevo examen · ExamGen{% endblock %}
+{% block content %}
+<section class="card">
+  <h2 style="margin-top:0">Nuevo examen</h2>
+  <form method="post" action="{{ url_for('exams.create_exam') }}" style="display:grid;gap:1rem;max-width:720px">
+    <label>
+      <span>Título</span>
+      <input name="title" type="text" required value="{{ form.title }}" />
+      {% if errors.title %}<small style="color:#b91c1c">{{ errors.title }}</small>{% endif %}
+    </label>
+
+    <label>
+      <span>Descripción</span>
+      <textarea name="description" rows="3">{{ form.description }}</textarea>
+    </label>
+
+    <label>
+      <span>Idioma</span>
+      <select name="language">
+        {% set lang = form.language or "es-ES" %}
+        <option value="es-ES" {{ "selected" if lang=="es-ES" else "" }}>Español (España)</option>
+        <option value="es-LA" {{ "selected" if lang=="es-LA" else "" }}>Español (LatAm)</option>
+        <option value="en-US" {{ "selected" if lang=="en-US" else "" }}>English (US)</option>
+      </select>
+    </label>
+
+    <div class="actions">
+      <button class="btn" type="submit">Crear</button>
+      <a class="btn secondary" href="{{ url_for('exams.list_exams') }}">Cancelar</a>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/examgen_web/templates/exams_list.html
+++ b/examgen_web/templates/exams_list.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block title %}Exámenes · ExamGen{% endblock %}
+{% block content %}
+<section class="card">
+  <header style="display:flex;justify-content:space-between;align-items:center;gap:1rem">
+    <h2 style="margin:0">Exámenes</h2>
+    <a class="btn" href="{{ url_for('exams.new_exam') }}">+ Nuevo</a>
+  </header>
+
+  {% if exams and exams|length > 0 %}
+    <div style="overflow-x:auto;margin-top:1rem">
+      <table>
+        <thead>
+          <tr>
+            <th style="white-space:nowrap">ID</th>
+            <th>Título</th>
+            <th style="white-space:nowrap">Idioma</th>
+            <th style="white-space:nowrap">Creado</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for e in exams %}
+          <tr>
+            <td>{{ e.id or e["id"] }}</td>
+            <td>{{ e.title or e["title"] }}</td>
+            <td>{{ e.language or e["language"] or "—" }}</td>
+            <td>
+              {% set ca = e.created_at or e["created_at"] %}
+              {{ ca if ca else "—" }}
+            </td>
+            <td style="text-align:right; white-space:nowrap">
+              <a class="btn secondary" href="{{ url_for('exams.exam_detail', exam_id=e.id or e['id']) }}">Abrir</a>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p style="margin-top:1rem;color:#475569">No hay exámenes todavía.</p>
+    <p><a class="btn" href="{{ url_for('exams.new_exam') }}">Crear el primero</a></p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/tests/test_exams_routes.py
+++ b/tests/test_exams_routes.py
@@ -1,0 +1,19 @@
+import pytest
+from examgen_web.app import app as flask_app
+
+
+@pytest.fixture()
+def client():
+    flask_app.testing = True
+    with flask_app.test_client() as c:
+        yield c
+
+
+def test_exams_list_ok(client):
+    r = client.get("/exams")
+    assert r.status_code == 200
+
+
+def test_new_exam_form_ok(client):
+    r = client.get("/exams/new")
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- register exams blueprint and implement list/create/detail routes with safe SQL fallback
- add exams list, form and detail templates
- cover exams listing and form with smoke tests

## Testing
- `python -m examgen_web.app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f23be8c30832984468792ce3c8116