### PR TITLE
feat(EXG-6): CRUD de Secciones y Preguntas (UI + endpoints) con dominio y fallback seguro

### DIFF
--- a/examgen_web/__init__.py
+++ b/examgen_web/__init__.py
@@ -1,7 +1,9 @@
 from flask import Flask
 from .routes.home import home_bp
 from .routes.health import health_bp
-from .routes.exams import exams_bp  # <- NUEVO
+from .routes.exams import exams_bp
+from .routes.sections import sections_bp      # <- NUEVO
+from .routes.questions import questions_bp    # <- NUEVO
 
 
 def create_app() -> Flask:
@@ -13,5 +15,7 @@ def create_app() -> Flask:
     # Blueprints
     app.register_blueprint(home_bp)
     app.register_blueprint(health_bp)
-    app.register_blueprint(exams_bp)  # <- NUEVO
+    app.register_blueprint(exams_bp)
+    app.register_blueprint(sections_bp)       # <- NUEVO
+    app.register_blueprint(questions_bp)      # <- NUEVO
     return app

--- a/examgen_web/routes/questions.py
+++ b/examgen_web/routes/questions.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+import json
+
+from flask import Blueprint, render_template, request, redirect, url_for, abort
+from sqlalchemy import text  # type: ignore
+
+from examgen_web.infra.db import get_session
+from examgen_web.infra import services as domain_services
+
+questions_bp = Blueprint("questions", __name__)
+
+# ---- Helpers ----
+
+def _domain_available(name: str) -> bool:
+    return getattr(domain_services, name, None) is not None
+
+
+def _section_columns(session) -> List[str]:
+    try:
+        return [r[1] for r in session.execute(text("PRAGMA table_info(section)")).fetchall()]
+    except Exception:
+        return []
+
+
+def _question_columns(session) -> List[str]:
+    try:
+        return [r[1] for r in session.execute(text("PRAGMA table_info(question)")).fetchall()]
+    except Exception:
+        return []
+
+
+def _get_section_fallback(session, section_id: int) -> Optional[Dict[str, Any]]:
+    row = session.execute(text("SELECT * FROM section WHERE id = :id"), {"id": section_id}).mappings().one_or_none()
+    return dict(row) if row else None
+
+
+def _get_exam_id_for_section(session, section_id: int) -> Optional[int]:
+    sec = _get_section_fallback(session, section_id)
+    return int(sec["exam_id"]) if sec and "exam_id" in sec else None
+
+
+def _get_question_fallback(session, question_id: int) -> Optional[Dict[str, Any]]:
+    row = session.execute(text("SELECT * FROM question WHERE id = :id"), {"id": question_id}).mappings().one_or_none()
+    return dict(row) if row else None
+
+
+def _as_json_if_possible(value: str) -> str:
+    """Si 'value' es JSON válido, lo dejamos. Si contiene ';;', lo convertimos a JSON array. En otro caso, lo devolvemos igual."""
+    if not value:
+        return value
+    try:
+        json.loads(value)
+        return value
+    except Exception:
+        pass
+    if ";;" in value:
+        parts = [p.strip() for p in value.split(";;") if p.strip()]
+        return json.dumps(parts, ensure_ascii=False)
+    return value
+
+
+def _insert_question_fallback(session, section_id: int, payload: Dict[str, Any]) -> Optional[int]:
+    cols = set(_question_columns(session))
+    if not cols:
+        return None
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    data: Dict[str, Any] = {"section_id": section_id} if "section_id" in cols else {}
+    for k in ("stem","type","choices","answer","difficulty","tags","metadata"):
+        if k in cols and k in payload:
+            v = payload[k]
+            if k in ("choices","tags"):
+                v = _as_json_if_possible(v)
+            data[k] = v
+    if "created_at" in cols:
+        data["created_at"] = now
+    if "updated_at" in cols:
+        data["updated_at"] = now
+    if not data:
+        return None
+    keys = list(data.keys())
+    placeholders = [f":{k}" for k in keys]
+    session.execute(text(f"INSERT INTO question ({', '.join(keys)}) VALUES ({', '.join(placeholders)})"), data)
+    session.commit()
+    try:
+        rid = session.execute(text("SELECT last_insert_rowid()")).scalar()
+        return int(rid) if isinstance(rid, int) else None
+    except Exception:
+        try:
+            rid = session.execute(text("SELECT id FROM question ORDER BY id DESC LIMIT 1")).scalar()
+            return int(rid) if isinstance(rid, int) else None
+        except Exception:
+            return None
+
+
+def _update_question_fallback(session, question_id: int, payload: Dict[str, Any]) -> None:
+    cols = set(_question_columns(session))
+    if not cols:
+        return
+    data: Dict[str, Any] = {}
+    for k in ("stem","type","choices","answer","difficulty","tags","metadata"):
+        if k in cols and (k in payload):
+            v = payload[k]
+            if k in ("choices","tags"):
+                v = _as_json_if_possible(v)
+            data[k] = v
+    if "updated_at" in cols:
+        data["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    if not data:
+        return
+    sets = ", ".join([f"{k} = :{k}" for k in data.keys()])
+    data["qid"] = question_id
+    session.execute(text(f"UPDATE question SET {sets} WHERE id = :qid"), data)
+    session.commit()
+
+# ---- Endpoints ----
+
+@questions_bp.get("/sections/<int:section_id>/questions/new")
+def new_question(section_id: int):
+    with get_session() as s:
+        exam_id = _get_exam_id_for_section(s, section_id)
+    if not isinstance(exam_id, int):
+        abort(404)
+    return render_template("question_form.html",
+                           mode="create",
+                           exam_id=exam_id,
+                           section_id=section_id,
+                           errors={},
+                           form={"stem":"", "type":"mcq", "choices":"", "answer":"", "difficulty":"medium", "tags":""})
+
+
+@questions_bp.post("/sections/<int:section_id>/questions")
+def create_question(section_id: int):
+    stem = (request.form.get("stem") or "").strip()
+    qtype = (request.form.get("type") or "").strip() or "mcq"
+    choices = (request.form.get("choices") or "").strip()
+    answer = (request.form.get("answer") or "").strip()
+    difficulty = (request.form.get("difficulty") or "").strip() or "medium"
+    tags = (request.form.get("tags") or "").strip()
+    metadata = (request.form.get("metadata") or "").strip()
+
+    errors = {}
+    if not stem:
+        errors["stem"] = "El enunciado es obligatorio."
+    if errors:
+        with get_session() as s:
+            exam_id = _get_exam_id_for_section(s, section_id)
+        return render_template("question_form.html",
+                               mode="create", exam_id=exam_id, section_id=section_id,
+                               errors=errors,
+                               form={"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata}), 400
+
+    with get_session() as s:
+        if _domain_available("QuestionService"):
+            try:
+                svc = domain_services.get_question_service(s)
+                payload = {"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata}
+                svc.add_question(section_id, payload)  # type: ignore[attr-defined]
+            except Exception:
+                _insert_question_fallback(s, section_id, {"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata})
+        else:
+            _insert_question_fallback(s, section_id, {"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata})
+
+        exam_id = _get_exam_id_for_section(s, section_id)
+
+    if isinstance(exam_id, int):
+        return redirect(url_for("exams.exam_detail", exam_id=exam_id))
+    abort(400)
+
+
+@questions_bp.get("/questions/<int:question_id>/edit")
+def edit_question(question_id: int):
+    with get_session() as s:
+        q = _get_question_fallback(s, question_id)
+        if not q:
+            abort(404)
+        sec_id = int(q["section_id"]) if "section_id" in q else None
+        exam_id = _get_exam_id_for_section(s, sec_id) if sec_id is not None else None
+    if not isinstance(exam_id, int):
+        abort(404)
+    form = {
+        "stem": q.get("stem",""),
+        "type": q.get("type","mcq"),
+        "choices": q.get("choices",""),
+        "answer": q.get("answer",""),
+        "difficulty": q.get("difficulty","medium"),
+        "tags": q.get("tags",""),
+        "metadata": q.get("metadata",""),
+    }
+    return render_template("question_form.html", mode="edit", exam_id=exam_id, section_id=sec_id, question_id=question_id, errors={}, form=form)
+
+
+@questions_bp.post("/questions/<int:question_id>")
+def update_question(question_id: int):
+    stem = (request.form.get("stem") or "").strip()
+    qtype = (request.form.get("type") or "").strip() or "mcq"
+    choices = (request.form.get("choices") or "").strip()
+    answer = (request.form.get("answer") or "").strip()
+    difficulty = (request.form.get("difficulty") or "").strip() or "medium"
+    tags = (request.form.get("tags") or "").strip()
+    metadata = (request.form.get("metadata") or "").strip()
+
+    errors = {}
+    if not stem:
+        errors["stem"] = "El enunciado es obligatorio."
+
+    with get_session() as s:
+        q = _get_question_fallback(s, question_id)
+        if not q:
+            abort(404)
+        sec_id = int(q["section_id"]) if "section_id" in q else None
+        exam_id = _get_exam_id_for_section(s, sec_id) if sec_id is not None else None
+
+    if errors:
+        return render_template("question_form.html", mode="edit", exam_id=exam_id, section_id=sec_id, question_id=question_id, errors=errors,
+                               form={"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata}), 400
+
+    with get_session() as s:
+        if _domain_available("QuestionService"):
+            try:
+                svc = domain_services.get_question_service(s)
+                payload = {"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata}
+                svc.update_question(question_id, payload)  # type: ignore[attr-defined]
+            except Exception:
+                _update_question_fallback(s, question_id, {"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata})
+        else:
+            _update_question_fallback(s, question_id, {"stem": stem, "type": qtype, "choices": choices, "answer": answer, "difficulty": difficulty, "tags": tags, "metadata": metadata})
+
+    if isinstance(exam_id, int):
+        return redirect(url_for("exams.exam_detail", exam_id=exam_id))
+    abort(400)

--- a/examgen_web/routes/sections.py
+++ b/examgen_web/routes/sections.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+
+from flask import Blueprint, render_template, request, redirect, url_for, abort
+from sqlalchemy import text  # type: ignore
+
+from examgen_web.infra.db import get_session
+from examgen_web.infra import services as domain_services
+
+sections_bp = Blueprint("sections", __name__)
+
+# ---- Helpers ----
+
+def _domain_available(name: str) -> bool:
+    return getattr(domain_services, name, None) is not None
+
+
+def _section_columns(session) -> List[str]:
+    try:
+        res = session.execute(text("PRAGMA table_info(section)"))
+        return [row[1] for row in res.fetchall()]
+    except Exception:
+        return []
+
+
+def _get_exam_fallback(session, exam_id: int) -> Optional[Dict[str, Any]]:
+    try:
+        row = session.execute(
+            text("SELECT * FROM exam WHERE id = :id"), {"id": exam_id}
+        ).mappings().one_or_none()
+        return dict(row) if row else None
+    except Exception:
+        return None
+
+
+def _insert_section_fallback(
+    session, exam_id: int, title: str, order: Optional[int]
+) -> Optional[int]:
+    cols = set(_section_columns(session))
+    if not cols:
+        return None
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    data: Dict[str, Any] = {"exam_id": exam_id} if "exam_id" in cols else {}
+    if "title" in cols:
+        data["title"] = title
+    if "order" in cols and order is not None:
+        data["order"] = order
+    if "created_at" in cols:
+        data["created_at"] = now
+    if "updated_at" in cols:
+        data["updated_at"] = now
+    if not data:
+        return None
+    keys = list(data.keys())
+    placeholders = [f":{k}" for k in keys]
+    session.execute(
+        text(
+            f"INSERT INTO section ({', '.join(keys)}) VALUES ({', '.join(placeholders)})"
+        ),
+        data,
+    )
+    session.commit()
+    try:
+        rid = session.execute(text("SELECT last_insert_rowid()")).scalar()
+        return int(rid) if isinstance(rid, int) else None
+    except Exception:
+        try:
+            rid = session.execute(
+                text("SELECT id FROM section ORDER BY id DESC LIMIT 1")
+            ).scalar()
+            return int(rid) if isinstance(rid, int) else None
+        except Exception:
+            return None
+
+# ---- Endpoints ----
+
+@sections_bp.get("/exams/<int:exam_id>/sections/new")
+def new_section(exam_id: int):
+    with get_session() as s:
+        exam = _get_exam_fallback(s, exam_id)
+    if not exam:
+        abort(404)
+    return render_template(
+        "section_form.html", exam=exam, errors={}, form={"title": "", "order": ""}
+    )
+
+
+@sections_bp.post("/exams/<int:exam_id>/sections")
+def create_section(exam_id: int):
+    title = (request.form.get("title") or "").strip()
+    order_raw = (request.form.get("order") or "").strip()
+    order = int(order_raw) if order_raw.isdigit() else None
+
+    errors = {}
+    if not title:
+        errors["title"] = "El título de la sección es obligatorio."
+
+    if errors:
+        return (
+            render_template(
+                "section_form.html",
+                exam={"id": exam_id},
+                errors=errors,
+                form={"title": title, "order": order_raw},
+            ),
+            400,
+        )
+
+    with get_session() as s:
+        if _domain_available("SectionService"):
+            try:
+                svc = domain_services.get_section_service(s)
+                svc.add_section(exam_id, title=title, order=order)  # type: ignore[attr-defined]
+            except Exception:
+                _insert_section_fallback(s, exam_id, title, order)
+        else:
+            _insert_section_fallback(s, exam_id, title, order)
+
+    return redirect(url_for("exams.exam_detail", exam_id=exam_id))

--- a/examgen_web/templates/exam_detail.html
+++ b/examgen_web/templates/exam_detail.html
@@ -16,10 +16,62 @@
 </section>
 
 <section class="card" style="margin-top:1rem">
-  <h3 style="margin-top:0">Secciones</h3>
-  <p style="color:#475569">La gestión de secciones y preguntas se añadirá en <strong>EXG‑6.4</strong>.</p>
-  <div class="actions">
-    <a class="btn disabled" aria-disabled="true" title="Disponible en EXG‑6.4">+ Añadir sección</a>
-  </div>
+  <header style="display:flex;justify-content:space-between;align-items:center;gap:1rem">
+    <h3 style="margin:0">Secciones</h3>
+    <a class="btn" href="/exams/{{ exam.id or exam['id'] }}/sections/new">+ Añadir sección</a>
+  </header>
+
+  {% if sections and sections|length > 0 %}
+    <div style="display:grid;gap:1rem;margin-top:1rem">
+      {% for sec in sections %}
+      <div style="border:1px solid #e5e7eb;border-radius:10px;padding:1rem">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:1rem">
+          <div>
+            <strong>Sección {{ loop.index }}:</strong>
+            <span>{{ sec.title or sec["title"] }}</span>
+            {% if sec.order or sec["order"] %}<span class="badge" style="margin-left:.5rem">Orden: {{ sec.order or sec["order"] }}</span>{% endif %}
+          </div>
+          <div class="actions">
+            <a class="btn secondary" href="/sections/{{ sec.id or sec['id'] }}/questions/new">+ Pregunta</a>
+          </div>
+        </div>
+
+        {% set qs = sec.questions or sec["questions"] %}
+        {% if qs and qs|length > 0 %}
+          <div style="overflow-x:auto;margin-top:.75rem">
+            <table>
+              <thead>
+                <tr>
+                  <th style="white-space:nowrap">#</th>
+                  <th>Enunciado</th>
+                  <th style="white-space:nowrap">Tipo</th>
+                  <th style="white-space:nowrap">Dificultad</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for q in qs %}
+                <tr>
+                  <td style="white-space:nowrap">{{ loop.index }}</td>
+                  <td>{{ q.stem or q["stem"] }}</td>
+                  <td style="white-space:nowrap">{{ q.type or q["type"] or "—" }}</td>
+                  <td style="white-space:nowrap">{{ q.difficulty or q["difficulty"] or "—" }}</td>
+                  <td style="text-align:right;white-space:nowrap">
+                    <a class="btn secondary" href="/questions/{{ q.id or q['id'] }}/edit">Editar</a>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p style="margin-top:.5rem;color:#475569">No hay preguntas en esta sección.</p>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p style="margin-top:1rem;color:#475569">Este examen aún no tiene secciones.</p>
+  {% endif %}
 </section>
 {% endblock %}

--- a/examgen_web/templates/question_form.html
+++ b/examgen_web/templates/question_form.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% if mode == "edit" %}
+  {% set page_title = "Editar pregunta" %}
+{% else %}
+  {% set page_title = "Nueva pregunta" %}
+{% endif %}
+{% block title %}{{ page_title }} · ExamGen{% endblock %}
+{% block content %}
+<section class="card">
+  <h2 style="margin-top:0">{{ page_title }}</h2>
+
+  {% if mode == "edit" %}
+    <form method="post" action="/questions/{{ question_id }}" style="display:grid;gap:1rem;max-width:880px">
+  {% else %}
+    <form method="post" action="/sections/{{ section_id }}/questions" style="display:grid;gap:1rem;max-width:880px">
+  {% endif %}
+
+    <label>
+      <span>Tipo</span>
+      {% set qtype = form.type or "mcq" %}
+      <select name="type">
+        <option value="mcq" {{ "selected" if qtype=="mcq" else "" }}>Opción múltiple</option>
+        <option value="true_false" {{ "selected" if qtype=="true_false" else "" }}>Verdadero/Falso</option>
+        <option value="short" {{ "selected" if qtype=="short" else "" }}>Respuesta corta</option>
+      </select>
+    </label>
+
+    <label>
+      <span>Enunciado</span>
+      <textarea name="stem" rows="4" required>{{ form.stem }}</textarea>
+      {% if errors.stem %}<small style="color:#b91c1c">{{ errors.stem }}</small>{% endif %}
+    </label>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
+      <label>
+        <span>Opciones (MCQ) — JSON o "A;;B;;C;;D"</span>
+        <textarea name="choices" rows="3">{{ form.choices }}</textarea>
+      </label>
+      <label>
+        <span>Respuesta</span>
+        <input name="answer" type="text" value="{{ form.answer }}" />
+      </label>
+    </div>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
+      <label>
+        <span>Dificultad</span>
+        {% set diff = form.difficulty or "medium" %}
+        <select name="difficulty">
+          <option value="easy" {{ "selected" if diff=="easy" else "" }}>Fácil</option>
+          <option value="medium" {{ "selected" if diff=="medium" else "" }}>Media</option>
+          <option value="hard" {{ "selected" if diff=="hard" else "" }}>Difícil</option>
+        </select>
+      </label>
+      <label>
+        <span>Tags — JSON o "tag1;;tag2"</span>
+        <input name="tags" type="text" value="{{ form.tags }}" />
+      </label>
+    </div>
+
+    <label>
+      <span>Metadata (opcional)</span>
+      <textarea name="metadata" rows="2">{{ form.metadata }}</textarea>
+    </label>
+
+    <div class="actions">
+      <button class="btn" type="submit">{{ "Guardar cambios" if mode=="edit" else "Crear" }}</button>
+      <a class="btn secondary" href="/exams/{{ exam_id }}">Cancelar</a>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/examgen_web/templates/section_form.html
+++ b/examgen_web/templates/section_form.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Nueva sección · ExamGen{% endblock %}
+{% block content %}
+<section class="card">
+  <h2 style="margin-top:0">Nueva sección</h2>
+  <form method="post" action="/exams/{{ exam.id or exam['id'] }}/sections" style="display:grid;gap:1rem;max-width:720px">
+    <label>
+      <span>Título</span>
+      <input name="title" type="text" required value="{{ form.title }}" />
+      {% if errors.title %}<small style="color:#b91c1c">{{ errors.title }}</small>{% endif %}
+    </label>
+
+    <label>
+      <span>Orden (opcional)</span>
+      <input name="order" type="number" min="1" value="{{ form.order }}" />
+    </label>
+
+    <div class="actions">
+      <button class="btn" type="submit">Crear</button>
+      <a class="btn secondary" href="/exams/{{ exam.id or exam['id'] }}">Cancelar</a>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/tests/test_sections_questions_routes.py
+++ b/tests/test_sections_questions_routes.py
@@ -1,0 +1,15 @@
+import pytest
+from examgen_web.app import app as flask_app
+
+
+@pytest.fixture()
+def client():
+    flask_app.testing = True
+    with flask_app.test_client() as c:
+        yield c
+
+
+def test_sections_new_requires_exam(client):
+    # 404 si el examen no existe (fallback)
+    r = client.get("/exams/999999/sections/new")
+    assert r.status_code in (200, 404)


### PR DESCRIPTION
## Summary
- register and wire sections & questions blueprints
- list sections and questions in exam detail with domain-service fallbacks
- add HTML forms, routes and smoke test for sections and questions

## Testing
- `python -m examgen_web.app`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f28f113e88329861e0e2f5b5be8ae