### PR TITLE
feat(EXG-6): previsualización A4 y exportadores CSV/JSON/PDF

### DIFF
--- a/examgen_web/__init__.py
+++ b/examgen_web/__init__.py
@@ -2,8 +2,10 @@ from flask import Flask
 from .routes.home import home_bp
 from .routes.health import health_bp
 from .routes.exams import exams_bp
-from .routes.sections import sections_bp      # <- NUEVO
-from .routes.questions import questions_bp    # <- NUEVO
+from .routes.sections import sections_bp
+from .routes.questions import questions_bp
+from .routes.preview import preview_bp      # <- NUEVO
+from .routes.export import export_bp        # <- NUEVO
 
 
 def create_app() -> Flask:
@@ -16,6 +18,8 @@ def create_app() -> Flask:
     app.register_blueprint(home_bp)
     app.register_blueprint(health_bp)
     app.register_blueprint(exams_bp)
-    app.register_blueprint(sections_bp)       # <- NUEVO
-    app.register_blueprint(questions_bp)      # <- NUEVO
+    app.register_blueprint(sections_bp)
+    app.register_blueprint(questions_bp)
+    app.register_blueprint(preview_bp)      # <- NUEVO
+    app.register_blueprint(export_bp)       # <- NUEVO
     return app

--- a/examgen_web/routes/export.py
+++ b/examgen_web/routes/export.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+from typing import Any, Dict, List
+import io
+import csv
+import json
+import re
+
+from flask import Blueprint, request, abort, Response, render_template
+from sqlalchemy import text  # type: ignore
+
+from examgen_web.infra.db import get_session
+from .preview import _load_exam_tree  # reutilizamos la carga normalizada
+
+export_bp = Blueprint("export", __name__)
+
+def _slugify(s: str, fallback: str = "exam") -> str:
+    if not s:
+        return fallback
+    s = re.sub(r"\s+", "-", s.strip())
+    s = re.sub(r"[^A-Za-z0-9\-_.]+", "", s)
+    return s or fallback
+
+def _bool(v: str | None, default: bool=False) -> bool:
+    if v is None:
+        return default
+    return v.lower() in ("1","true","yes","on")
+
+def _csv_bytes(tree: Dict[str, Any], with_solutions: bool) -> bytes:
+    # CSV columnas: section, index, type, stem, choices, answer, difficulty, tags
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(["section", "index", "type", "stem", "choices", "answer" if with_solutions else "answer_included=false", "difficulty", "tags"])
+    for idx_s, sec in enumerate(tree["sections"], start=1):
+        title = sec.get("title") or f"Sección {idx_s}"
+        for idx_q, q in enumerate(sec.get("questions", []), start=1):
+            choices = "; ".join(q.get("choices") or [])
+            tags = "; ".join(q.get("tags") or [])
+            answer = q.get("answer") if with_solutions else ""
+            w.writerow([title, idx_q, q.get("type") or "", q.get("stem") or "", choices, answer, q.get("difficulty") or "", tags])
+    return buf.getvalue().encode("utf-8")
+
+def _json_bytes(tree: Dict[str, Any], with_solutions: bool) -> bytes:
+    # Si no se incluyen soluciones, vaciamos el campo 'answer'
+    payload = {
+        "exam": tree["exam"],
+        "sections": []
+    }
+    for sec in tree["sections"]:
+        s_out = {k: sec.get(k) for k in ("id","exam_id","title","order")}
+        s_out["questions"] = []
+        for q in sec.get("questions", []):
+            q_out = {k: q.get(k) for k in ("id","section_id","type","stem","choices","difficulty","tags","rationale","metadata")}
+            q_out["answer"] = q.get("answer") if with_solutions else None
+            s_out["questions"].append(q_out)
+        payload["sections"].append(s_out)
+    return json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+
+# ---------- Endpoint ----------
+
+@export_bp.post("/exams/<int:exam_id>/export")
+def export_exam(exam_id: int):
+    fmt = (request.args.get("fmt") or "").lower()
+    if fmt not in ("csv","json","pdf"):
+        abort(400, "Parámetro fmt inválido. Use csv|json|pdf.")
+    with_solutions = _bool(request.args.get("solutions"), default=False)
+    download = _bool(request.args.get("download"), default=True)
+
+    with get_session() as s:
+        tree = _load_exam_tree(s, exam_id)
+    if not tree:
+        abort(404)
+
+    exam_title = tree["exam"].get("title") or f"exam-{exam_id}"
+    base = _slugify(exam_title)
+
+    if fmt == "csv":
+        body = _csv_bytes(tree, with_solutions)
+        resp = Response(body, mimetype="text/csv; charset=utf-8")
+        if download:
+            resp.headers["Content-Disposition"] = f'attachment; filename="{base}.csv"'
+        return resp
+
+    if fmt == "json":
+        body = _json_bytes(tree, with_solutions)
+        resp = Response(body, mimetype="application/json; charset=utf-8")
+        if download:
+            resp.headers["Content-Disposition"] = f'attachment; filename="{base}.json"'
+        return resp
+
+    # PDF
+    try:
+        from weasyprint import HTML  # type: ignore
+    except Exception:
+        abort(501, "Exportación a PDF requiere 'weasyprint' instalado en local.")
+
+    # Renderizamos HTML con la misma estructura y lo convertimos a PDF
+    html_str = render_template("pdf_template.html",
+                               exam=tree["exam"],
+                               sections=tree["sections"],
+                               show_solutions=with_solutions)
+    pdf_bytes = HTML(string=html_str, base_url=None).write_pdf()
+    resp = Response(pdf_bytes, mimetype="application/pdf")
+    if download:
+        resp.headers["Content-Disposition"] = f'attachment; filename="{base}.pdf"'
+    return resp

--- a/examgen_web/routes/preview.py
+++ b/examgen_web/routes/preview.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+import json
+
+from flask import Blueprint, render_template, request, abort
+from sqlalchemy import text  # type: ignore
+
+from examgen_web.infra.db import get_session
+from examgen_web.infra import services as domain_services
+
+preview_bp = Blueprint("preview", __name__)
+
+# ---------- Helpers comunes (dominio + fallback) ----------
+
+def _domain_available(name: str) -> bool:
+    return getattr(domain_services, name, None) is not None
+
+def _parse_json_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(x) for x in value]
+    if isinstance(value, str):
+        v = value.strip()
+        if not v:
+            return []
+        # JSON válido
+        try:
+            data = json.loads(v)
+            if isinstance(data, list):
+                return [str(x) for x in data]
+        except Exception:
+            pass
+        # "A;;B;;C"
+        if ";;" in v:
+            return [p.strip() for p in v.split(";;") if p.strip()]
+    return [str(value)]
+
+def _get_exam_fallback(session, exam_id: int) -> Optional[Dict[str, Any]]:
+    try:
+        cols = [r[1] for r in session.execute(text("PRAGMA table_info(exam)")).fetchall()]
+    except Exception:
+        cols = []
+    if not cols:
+        return None
+    row = session.execute(
+        text("SELECT * FROM exam WHERE id = :id"), {"id": exam_id}
+    ).mappings().one_or_none()
+    return dict(row) if row else None
+
+def _list_sections_fallback(session, exam_id: int) -> List[Dict[str, Any]]:
+    cols = [r[1] for r in session.execute(text("PRAGMA table_info(section)")).fetchall()]
+    order_by = '"order"' if "order" in cols else "id" if "id" in cols else None
+    sql = "SELECT * FROM section WHERE exam_id = :eid"
+    if order_by:
+        sql += f" ORDER BY {order_by}"
+    return [dict(r) for r in session.execute(text(sql), {"eid": exam_id}).mappings().all()]
+
+def _list_questions_fallback(session, section_id: int) -> List[Dict[str, Any]]:
+    sql = "SELECT * FROM question WHERE section_id = :sid"
+    return [dict(r) for r in session.execute(text(sql), {"sid": section_id}).mappings().all()]
+
+def _normalize_question(q: Dict[str, Any]) -> Dict[str, Any]:
+    # Asegurar claves esperadas por la vista/export
+    return {
+        "id": q.get("id"),
+        "section_id": q.get("section_id"),
+        "type": q.get("type") or q.get("qtype") or "mcq",
+        "stem": q.get("stem") or q.get("text") or "",
+        "choices": _parse_json_list(q.get("choices")),
+        "answer": q.get("answer"),
+        "difficulty": q.get("difficulty"),
+        "tags": _parse_json_list(q.get("tags")),
+        "rationale": q.get("rationale"),
+        "metadata": q.get("metadata"),
+    }
+
+def _load_exam_tree(session, exam_id: int) -> Optional[Dict[str, Any]]:
+    # Exam
+    if _domain_available("ExamService"):
+        try:
+            esvc = domain_services.get_exam_service(session)
+            e = esvc.get_exam(exam_id)  # type: ignore[attr-defined]
+            if e:
+                exam = {
+                    "id": getattr(e, "id", None),
+                    "title": getattr(e, "title", None),
+                    "description": getattr(e, "description", None),
+                    "language": getattr(e, "language", None),
+                    "created_at": getattr(e, "created_at", None),
+                }
+            else:
+                exam = None
+        except Exception:
+            exam = _get_exam_fallback(session, exam_id)
+    else:
+        exam = _get_exam_fallback(session, exam_id)
+
+    if not exam:
+        return None
+
+    # Sections
+    if _domain_available("SectionService"):
+        try:
+            ssvc = domain_services.get_section_service(session)
+            sections = [{
+                "id": getattr(s, "id", None),
+                "exam_id": getattr(s, "exam_id", None),
+                "title": getattr(s, "title", None),
+                "order": getattr(s, "order", None),
+            } for s in ssvc.list_sections(exam_id)]  # type: ignore[attr-defined]
+        except Exception:
+            sections = _list_sections_fallback(session, exam_id)
+    else:
+        sections = _list_sections_fallback(session, exam_id)
+
+    # Questions por sección
+    out_sections: List[Dict[str, Any]] = []
+    for sec in sections:
+        sid = sec.get("id")
+        if sid is None:
+            continue
+        if _domain_available("QuestionService"):
+            try:
+                qsvc = domain_services.get_question_service(session)
+                qlist = qsvc.list_questions(sid)  # type: ignore[attr-defined]
+                qs = [_normalize_question({
+                    "id": getattr(q, "id", None),
+                    "section_id": getattr(q, "section_id", None),
+                    "type": getattr(q, "type", None),
+                    "stem": getattr(q, "stem", getattr(q, "text", "")),
+                    "choices": getattr(q, "choices", None),
+                    "answer": getattr(q, "answer", None),
+                    "difficulty": getattr(q, "difficulty", None),
+                    "tags": getattr(q, "tags", None),
+                    "rationale": getattr(q, "rationale", None),
+                    "metadata": getattr(q, "metadata", None),
+                }) for q in qlist]
+            except Exception:
+                qs = [_normalize_question(q) for q in _list_questions_fallback(session, sid)]
+        else:
+            qs = [_normalize_question(q) for q in _list_questions_fallback(session, sid)]
+
+        out_sections.append({**sec, "questions": qs})
+
+    return {"exam": exam, "sections": out_sections}
+
+# ---------- Endpoint ----------
+
+@preview_bp.get("/exams/<int:exam_id>/preview")
+def preview(exam_id: int):
+    show_solutions = (request.args.get("solutions") or "").lower() in ("1", "true", "yes", "on")
+    with get_session() as s:
+        tree = _load_exam_tree(s, exam_id)
+    if not tree:
+        abort(404)
+
+    return render_template(
+        "preview.html",
+        exam=tree["exam"],
+        sections=tree["sections"],
+        show_solutions=show_solutions
+    )

--- a/examgen_web/templates/pdf_template.html
+++ b/examgen_web/templates/pdf_template.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <title>{{ exam.title or "Examen" }}</title>
+  <style>
+    @page { size: A4; margin: 20mm; }
+    body { font-family: "DejaVu Sans", system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", Arial; color: #0f172a; }
+    h1,h2,h3 { margin: 0 0 .4rem 0; }
+    .exam-meta { color: #475569; font-size: .95rem; margin-bottom: .8rem; }
+    .badge { font-size: .75rem; padding: .1rem .4rem; border: 1px solid #cbd5e1; border-radius: .4rem; }
+    .section { page-break-inside: avoid; margin-top: 1rem; }
+    .question { margin: .5rem 0; }
+    .choices { margin: .2rem 0 .3rem 1rem; }
+    .answer { margin: .2rem 0; color: #0b5; }
+    ol { padding-left: 1.1rem; }
+    ul { padding-left: 1.1rem; }
+  </style>
+</head>
+<body>
+  <h2>{{ exam.title or exam["title"] }}</h2>
+  <div class="exam-meta">
+    {% if exam.description or exam["description"] %}<div>{{ exam.description or exam["description"] }}</div>{% endif %}
+    {% if exam.language or exam["language"] %}<span class="badge">Idioma: {{ exam.language or exam["language"] }}</span>{% endif %}
+  </div>
+
+  {% for sec in sections %}
+    <section class="section">
+      <h3>Sección {{ loop.index }} — {{ sec.title or sec["title"] }}</h3>
+      {% set qs = sec.questions or sec["questions"] %}
+      {% if qs and qs|length > 0 %}
+        <ol>
+          {% for q in qs %}
+            <li class="question">
+              <div>{{ q.stem or q["stem"] }}</div>
+              {% set choices = q.choices or q["choices"] %}
+              {% if choices and choices|length > 0 %}
+                <ul class="choices">
+                  {% for c in choices %}
+                    <li>{{ c }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+              {% if show_solutions and (q.answer or q["answer"]) %}
+                <div class="answer"><strong>Solución:</strong> {{ q.answer or q["answer"] }}</div>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ol>
+      {% else %}
+        <p>No hay preguntas en esta sección.</p>
+      {% endif %}
+    </section>
+  {% endfor %}
+</body>
+</html>

--- a/examgen_web/templates/preview.html
+++ b/examgen_web/templates/preview.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% block title %}Previsualización · {{ exam.title or "Examen" }}{% endblock %}
+{% block head %}
+<style>
+  /* Diseño imprimible A4 */
+  @page { size: A4; margin: 20mm; }
+  .exam-wrapper { max-width: 850px; margin: 0 auto; }
+  .exam-header { margin-bottom: 1rem; }
+  .exam-meta { color: #475569; font-size: .95rem; }
+  .section { margin-top: 1.25rem; }
+  .section h3 { margin: .2rem 0 .5rem; }
+  .question { margin: .65rem 0; }
+  .choices { margin: .25rem 0 .5rem 1.25rem; }
+  .answer { margin: .25rem 0; color: #064e3b; }
+  .toolbar { display:flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+  .btn-link { text-decoration: none; border: 1px solid #1f2937; padding: .45rem .8rem; border-radius: .6rem; }
+  .muted { color: #64748b; }
+  .badge { font-size: .75rem; padding: .2rem .5rem; border-radius: .5rem; border: 1px solid #cbd5e1; }
+  @media print {
+    .toolbar, header, footer { display: none; }
+    .exam-wrapper { max-width: 100%; }
+  }
+</style>
+{% endblock %}
+{% block content %}
+<section class="card">
+  <div class="exam-wrapper">
+    <div class="toolbar">
+      <a class="btn-link" href="/exams/{{ exam.id or exam['id'] }}">← Volver</a>
+      <form method="post" action="/exams/{{ exam.id or exam['id'] }}/export?fmt=csv&download=1{% if show_solutions %}&solutions=1{% endif %}">
+        <button class="btn" type="submit">Exportar CSV</button>
+      </form>
+      <form method="post" action="/exams/{{ exam.id or exam['id'] }}/export?fmt=json&download=1{% if show_solutions %}&solutions=1{% endif %}">
+        <button class="btn" type="submit">Exportar JSON</button>
+      </form>
+      <form method="post" action="/exams/{{ exam.id or exam['id'] }}/export?fmt=pdf&download=1{% if show_solutions %}&solutions=1{% endif %}">
+        <button class="btn" type="submit">Exportar PDF</button>
+      </form>
+      {% if show_solutions %}
+        <a class="btn-link" href="?solutions=0">Ocultar soluciones</a>
+      {% else %}
+        <a class="btn-link" href="?solutions=1">Mostrar soluciones</a>
+      {% endif %}
+      <span class="muted">Imprime esta página (Ctrl/Cmd+P) para una copia rápida.</span>
+    </div>
+
+    <header class="exam-header">
+      <h2 style="margin:0">{{ exam.title or exam["title"] }}</h2>
+      {% set lang = exam.language or exam["language"] %}
+      <div class="exam-meta">
+        {% if exam.description or exam["description"] %}<div>{{ exam.description or exam["description"] }}</div>{% endif %}
+        {% if lang %}<span class="badge">Idioma: {{ lang }}</span>{% endif %}
+      </div>
+    </header>
+
+    {% for sec in sections %}
+      <section class="section">
+        <h3>Sección {{ loop.index }} — {{ sec.title or sec["title"] }}</h3>
+        {% set qs = sec.questions or sec["questions"] %}
+        {% if qs and qs|length > 0 %}
+          <ol>
+            {% for q in qs %}
+              <li class="question">
+                <div>{{ q.stem or q["stem"] }}</div>
+                {% set choices = q.choices or q["choices"] %}
+                {% if choices and choices|length > 0 %}
+                  <ul class="choices">
+                    {% for c in choices %}
+                      <li>{{ c }}</li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
+                {% if show_solutions and (q.answer or q["answer"]) %}
+                  <div class="answer"><strong>Solución:</strong> {{ q.answer or q["answer"] }}</div>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ol>
+        {% else %}
+          <p class="muted">No hay preguntas en esta sección.</p>
+        {% endif %}
+      </section>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_preview_export_routes.py
+++ b/tests/test_preview_export_routes.py
@@ -1,0 +1,18 @@
+import pytest
+from examgen_web.app import app as flask_app
+
+
+@pytest.fixture()
+def client():
+    flask_app.testing = True
+    with flask_app.test_client() as c:
+        yield c
+
+def test_preview_status(client):
+    # Si no existe el examen, puede ser 404. El objetivo es que la ruta responda.
+    r = client.get("/exams/1/preview")
+    assert r.status_code in (200, 404)
+
+def test_export_requires_fmt(client):
+    r = client.post("/exams/1/export")
+    assert r.status_code in (400, 404)  # 400 por fmt inválido o 404 por inexistente


### PR DESCRIPTION
## Summary
- add preview blueprint with A4-friendly HTML
- implement CSV/JSON/PDF export route using domain services with SQL fallbacks
- provide smoke tests for preview and export routes

## Testing
- `python -m examgen_web.app`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f2dce2a5883298c6c6a637ee84627