### PR TITLE
feat(EXG-6): export streaming (CSV/JSON) con stream_with_context + Historian JSONL local

### DIFF
--- a/examgen_web/infra/history.py
+++ b/examgen_web/infra/history.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+# Reutilizamos directorio local del usuario (igual filosofía que config.py)
+try:
+    from platformdirs import user_data_dir  # type: ignore
+except Exception:
+    user_data_dir = None  # type: ignore
+
+APP_NAME = "ExamGen"
+
+def _base_dir() -> Path:
+    if user_data_dir:
+        base = Path(user_data_dir(APP_NAME))
+    else:
+        base = Path.home() / f".{APP_NAME.lower()}"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+def _events_path() -> Path:
+    d = _base_dir() / "history"
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "events.jsonl"
+
+@dataclass
+class Event:
+    ts: str
+    exam_id: Optional[int]
+    entity: str
+    action: str
+    entity_id: Optional[int]
+    summary: Optional[str]
+    before: Optional[dict]
+    after: Optional[dict]
+    extra: Optional[dict]
+    source: str = "web"
+
+def record_event(
+    *,
+    exam_id: Optional[int],
+    entity: str,
+    action: str,
+    entity_id: Optional[int] = None,
+    summary: Optional[str] = None,
+    before: Optional[dict] = None,
+    after: Optional[dict] = None,
+    extra: Optional[dict] = None,
+) -> None:
+    event = Event(
+        ts=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        exam_id=exam_id,
+        entity=entity,
+        action=action,
+        entity_id=entity_id,
+        summary=summary,
+        before=before,
+        after=after,
+        extra=extra,
+    )
+    p = _events_path()
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event.__dict__, ensure_ascii=False) + "\n")
+
+def list_events_for_exam(exam_id: int, limit: int = 25) -> list[dict]:
+    p = _events_path()
+    if not p.exists():
+        return []
+    # Estrategia simple: leer todo y filtrar (válido en local para tamaños típicos)
+    with p.open("r", encoding="utf-8") as f:
+        lines = f.readlines()
+    out: list[dict] = []
+    for line in reversed(lines):
+        try:
+            ev = json.loads(line)
+            if ev.get("exam_id") == exam_id:
+                out.append(ev)
+                if len(out) >= limit:
+                    break
+        except Exception:
+            continue
+    return out

--- a/examgen_web/routes/export.py
+++ b/examgen_web/routes/export.py
@@ -5,11 +5,10 @@ import csv
 import json
 import re
 
-from flask import Blueprint, request, abort, Response, render_template
-from sqlalchemy import text  # type: ignore
+from flask import Blueprint, request, abort, Response, render_template, stream_with_context
 
 from examgen_web.infra.db import get_session
-from .preview import _load_exam_tree  # reutilizamos la carga normalizada
+from .preview import _load_exam_tree  # reutilizamos normalización del árbol
 
 export_bp = Blueprint("export", __name__)
 
@@ -25,11 +24,19 @@ def _bool(v: str | None, default: bool=False) -> bool:
         return default
     return v.lower() in ("1","true","yes","on")
 
-def _csv_bytes(tree: Dict[str, Any], with_solutions: bool) -> bytes:
-    # CSV columnas: section, index, type, stem, choices, answer, difficulty, tags
+# ------------------ STREAMING HELPERS ------------------
+
+def _csv_stream(tree: Dict[str, Any], with_solutions: bool):
+    """
+    Genera CSV línea a línea usando csv.writer sobre un buffer pequeño por fila.
+    """
     buf = io.StringIO()
     w = csv.writer(buf)
+    # Cabecera
     w.writerow(["section", "index", "type", "stem", "choices", "answer" if with_solutions else "answer_included=false", "difficulty", "tags"])
+    yield buf.getvalue()
+    buf.seek(0); buf.truncate(0)
+
     for idx_s, sec in enumerate(tree["sections"], start=1):
         title = sec.get("title") or f"Sección {idx_s}"
         for idx_q, q in enumerate(sec.get("questions", []), start=1):
@@ -37,25 +44,48 @@ def _csv_bytes(tree: Dict[str, Any], with_solutions: bool) -> bytes:
             tags = "; ".join(q.get("tags") or [])
             answer = q.get("answer") if with_solutions else ""
             w.writerow([title, idx_q, q.get("type") or "", q.get("stem") or "", choices, answer, q.get("difficulty") or "", tags])
-    return buf.getvalue().encode("utf-8")
+            yield buf.getvalue()
+            buf.seek(0); buf.truncate(0)
 
-def _json_bytes(tree: Dict[str, Any], with_solutions: bool) -> bytes:
-    # Si no se incluyen soluciones, vaciamos el campo 'answer'
-    payload = {
-        "exam": tree["exam"],
-        "sections": []
-    }
-    for sec in tree["sections"]:
+def _json_stream(tree: Dict[str, Any], with_solutions: bool):
+    """
+    Emite JSON válido por partes: { "exam": {...}, "sections": [ { ... "questions": [ {...}, ... ] }, ... ] }
+    """
+    # Encabezado + exam
+    yield "{\n  \"exam\": "
+    yield json.dumps(tree["exam"], ensure_ascii=False)
+    yield ",\n  \"sections\": ["
+
+    for i, sec in enumerate(tree["sections"]):
+        if i > 0:
+            yield ","
+        # Abrir sección
         s_out = {k: sec.get(k) for k in ("id","exam_id","title","order")}
-        s_out["questions"] = []
-        for q in sec.get("questions", []):
-            q_out = {k: q.get(k) for k in ("id","section_id","type","stem","choices","difficulty","tags","rationale","metadata")}
-            q_out["answer"] = q.get("answer") if with_solutions else None
-            s_out["questions"].append(q_out)
-        payload["sections"].append(s_out)
-    return json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        yield "\n    {"
+        yield "\"id\": " + json.dumps(s_out.get("id"), ensure_ascii=False)
+        yield ", \"exam_id\": " + json.dumps(s_out.get("exam_id"), ensure_ascii=False)
+        yield ", \"title\": " + json.dumps(s_out.get("title"), ensure_ascii=False)
+        yield ", \"order\": " + json.dumps(s_out.get("order"), ensure_ascii=False)
+        yield ", \"questions\": ["
 
-# ---------- Endpoint ----------
+        qs = sec.get("questions", [])
+        for j, q in enumerate(qs):
+            if j > 0:
+                yield ","
+            q_out = {k: q.get(k) for k in ("id","section_id","type","stem","choices","difficulty","tags","rationale","metadata")}
+            if not with_solutions:
+                q_out["answer"] = None
+            else:
+                q_out["answer"] = q.get("answer")
+            yield "\n      " + json.dumps(q_out, ensure_ascii=False)
+
+        # Cerrar sección
+        yield "\n    ]}"  # end questions + section
+
+    # Cerrar documento
+    yield "\n  ]\n}\n"
+
+# ------------------ ROUTE ------------------
 
 @export_bp.post("/exams/<int:exam_id>/export")
 def export_exam(exam_id: int):
@@ -65,6 +95,8 @@ def export_exam(exam_id: int):
     with_solutions = _bool(request.args.get("solutions"), default=False)
     download = _bool(request.args.get("download"), default=True)
 
+    # Cargamos el árbol normalizado (puede ocupar memoria si el examen es enorme);
+    # el streaming evita construir un único buffer de salida gigante.
     with get_session() as s:
         tree = _load_exam_tree(s, exam_id)
     if not tree:
@@ -74,26 +106,25 @@ def export_exam(exam_id: int):
     base = _slugify(exam_title)
 
     if fmt == "csv":
-        body = _csv_bytes(tree, with_solutions)
-        resp = Response(body, mimetype="text/csv; charset=utf-8")
+        gen = _csv_stream(tree, with_solutions)
+        resp = Response(stream_with_context(gen), mimetype="text/csv; charset=utf-8")
         if download:
             resp.headers["Content-Disposition"] = f'attachment; filename="{base}.csv"'
         return resp
 
     if fmt == "json":
-        body = _json_bytes(tree, with_solutions)
-        resp = Response(body, mimetype="application/json; charset=utf-8")
+        gen = _json_stream(tree, with_solutions)
+        resp = Response(stream_with_context(gen), mimetype="application/json; charset=utf-8")
         if download:
             resp.headers["Content-Disposition"] = f'attachment; filename="{base}.json"'
         return resp
 
-    # PDF
+    # PDF (no streaming por ahora; se mantiene comportamiento de EXG-6.5)
     try:
         from weasyprint import HTML  # type: ignore
     except Exception:
         abort(501, "Exportación a PDF requiere 'weasyprint' instalado en local.")
 
-    # Renderizamos HTML con la misma estructura y lo convertimos a PDF
     html_str = render_template("pdf_template.html",
                                exam=tree["exam"],
                                sections=tree["sections"],

--- a/examgen_web/templates/exam_detail.html
+++ b/examgen_web/templates/exam_detail.html
@@ -74,4 +74,34 @@
     <p style="margin-top:1rem;color:#475569">Este examen aún no tiene secciones.</p>
   {% endif %}
 </section>
+
+<section class="card" style="margin-top:1rem">
+  <h3 style="margin-top:0">Historial</h3>
+  {% if events and events|length > 0 %}
+    <div style="overflow-x:auto">
+      <table>
+        <thead>
+          <tr>
+            <th style="white-space:nowrap">Fecha (UTC)</th>
+            <th>Acción</th>
+            <th>Entidad</th>
+            <th>Detalle</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for ev in events %}
+          <tr>
+            <td style="white-space:nowrap">{{ ev.ts }}</td>
+            <td style="white-space:nowrap">{{ ev.action }}</td>
+            <td style="white-space:nowrap">{{ ev.entity }}{% if ev.entity_id %} #{{ ev.entity_id }}{% endif %}</td>
+            <td>{{ ev.summary or "" }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p style="color:#475569">No hay eventos registrados todavía.</p>
+  {% endif %}
+</section>
 {% endblock %}

--- a/tests/test_export_streaming.py
+++ b/tests/test_export_streaming.py
@@ -1,0 +1,19 @@
+import pytest
+from examgen_web.app import app as flask_app
+
+@pytest.fixture()
+def client():
+    flask_app.testing = True
+    with flask_app.test_client() as c:
+        yield c
+
+def test_export_fmt_required(client):
+    r = client.post("/exams/1/export")
+    assert r.status_code in (400, 404)
+
+def test_streaming_headers_when_exists(client):
+    # Si el examen no existe, será 404; este test es smoke de ruta.
+    r = client.post("/exams/1/export?fmt=json")
+    assert r.status_code in (200, 404)
+    if r.status_code == 200:
+        assert "application/json" in r.headers.get("Content-Type", "")


### PR DESCRIPTION
## Summary
- add local JSONL historian to log exam events
- stream exam exports as CSV/JSON
- record create/update events for exams, sections, and questions

## Testing
- `python -m examgen_web.app`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f39ac9028832997fa7aff418be42f