### PR TITLE
feat(EXG-7.1): habilitar /exams (listar) + base UI moderna

### DIFF
--- a/examgen_web/__init__.py
+++ b/examgen_web/__init__.py
@@ -1,0 +1,1 @@
+"""ExamGen minimal web package."""

--- a/examgen_web/app.py
+++ b/examgen_web/app.py
@@ -1,0 +1,10 @@
+from flask import Flask
+from .blueprints.exams import bp as exams_bp
+
+
+def create_app() -> Flask:
+    app = Flask(__name__, static_folder="static", template_folder="templates")
+    # Navegación sin barra final y registro del blueprint de exámenes
+    app.url_map.strict_slashes = False
+    app.register_blueprint(exams_bp, url_prefix="/exams")
+    return app

--- a/examgen_web/blueprints/exams.py
+++ b/examgen_web/blueprints/exams.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from typing import Any, Dict, Iterable, List
+
+from flask import Blueprint, Response, current_app, render_template, stream_with_context
+
+bp = Blueprint("exams", __name__)
+
+
+# --- Helpers: dominio primero; si falla, fallback SQL ---
+def _db_path_from_url(url: str) -> str:
+    # soporta sqlite:///./examgen.db y rutas absolutas/relativas
+    if not url or not url.startswith("sqlite"):
+        return "./examgen.db"
+    path = url.split("///", 1)[-1]
+    return path
+
+
+def _detect_exams_table(conn: sqlite3.Connection) -> Dict[str, Any] | None:
+    # heurística: buscar tabla con columnas típicas
+    candidates: List[Dict[str, Any]] = []
+    tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    for (tname,) in tables:
+        cols = conn.execute(f"PRAGMA table_info('{tname}')").fetchall()
+        colnames = {c[1].lower() for c in cols}
+        if {"id"} <= colnames and ({"title"} <= colnames or {"name"} <= colnames):
+            score = 0
+            for k in ("created_at", "created", "inserted_at"):
+                if k in colnames:
+                    score += 1
+            candidates.append({"name": tname, "cols": colnames, "score": score})
+    if not candidates:
+        return None
+    # priorizar por score y nombre amistoso
+    candidates.sort(key=lambda c: (c["score"], "exam" in c["name"].lower()), reverse=True)
+    return candidates[0]
+
+
+def _list_exams_fallback(limit: int = 50) -> List[Dict[str, Any]]:
+    url = os.getenv("EXAMGEN_DB_URL", "sqlite:///./examgen.db")
+    path = _db_path_from_url(url)
+    if not os.path.exists(path):
+        return []
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        meta = _detect_exams_table(conn)
+        if not meta:
+            return []
+        t = meta["name"]
+        # columnas habituales; seleccionar lo disponible
+        cols_pref = [
+            "id",
+            "title",
+            "name",
+            "created_at",
+            "created",
+            "updated_at",
+            "updated",
+        ]
+        cols = [c for c in cols_pref if c in meta["cols"]]
+        if not cols:
+            return []
+        sql = f"SELECT {', '.join(cols)} FROM {t} ORDER BY 1 DESC LIMIT ?"
+        rows = conn.execute(sql, (limit,)).fetchall()
+        data: List[Dict[str, Any]] = []
+        for r in rows:
+            d = dict(r)
+            d.setdefault("title", d.get("name"))
+            data.append({"id": d.get("id"), "title": d.get("title"), "raw": d})
+        return data
+    finally:
+        conn.close()
+
+
+def list_exams(limit: int = 50) -> List[Dict[str, Any]]:
+    # Dominio primero (si existiese un servicio expuesto)
+    try:
+        # Ejemplo: from src.examgen.services import list_exams as _svc
+        # return _svc(limit=limit)
+        raise ImportError  # fuerza fallback si no hay servicio
+    except Exception:
+        return _list_exams_fallback(limit=limit)
+
+
+# --- Rutas ---
+@bp.get("/")
+def exams_index() -> str:
+    items = list_exams()
+    return render_template("exams/list.html", items=items)
+
+
+def _stream_json(items: Iterable[Dict[str, Any]]) -> Iterable[str]:
+    yield "["
+    first = True
+    for it in items:
+        if not first:
+            yield ","
+        yield json.dumps(it["raw"], ensure_ascii=False)
+        first = False
+    yield "]"
+
+
+@bp.get("/exams.json")
+def export_json() -> Response:
+    items = list_exams(limit=10000)
+    return Response(
+        stream_with_context(_stream_json(items)),
+        mimetype="application/json",
+    )
+
+
+def _stream_csv(items: Iterable[Dict[str, Any]]) -> Iterable[str]:
+    # encabezados dinámicos de la primera fila
+    it = list(items)
+    if not it:
+        yield ""
+        return
+    headers = list(it[0]["raw"].keys())
+    yield ",".join(headers) + "\n"
+    for row in it:
+        vals = [str(row["raw"].get(h, "")) for h in headers]
+        yield ",".join(vals) + "\n"
+
+
+@bp.get("/exams.csv")
+def export_csv() -> Response:
+    items = list_exams(limit=10000)
+    return Response(
+        stream_with_context(_stream_csv(items)),
+        mimetype="text/csv; charset=utf-8",
+    )

--- a/examgen_web/static/app.css
+++ b/examgen_web/static/app.css
@@ -1,0 +1,26 @@
+:root{
+  --bg:#0b1220; --panel:#0f172a; --text:#e5e7eb; --muted:#94a3b8; --accent:#7dd3fc; --border:#23304a;
+  --radius:12px; --space:16px; --maxw:1100px;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0; background:var(--bg); color:var(--text);
+  font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;
+}
+a{color:var(--accent); text-decoration:none}
+a:hover{text-decoration:underline}
+.topbar{display:flex; align-items:center; justify-content:space-between; padding:12px var(--space); border-bottom:1px solid var(--border); background:rgba(15,23,42,.7); backdrop-filter:saturate(150%) blur(6px); position:sticky; top:0}
+.topbar .brand a{font-weight:700; letter-spacing:.2px}
+.topbar .menu{display:flex; gap:16px; list-style:none; margin:0; padding:0}
+.container{max-width:var(--maxw); margin:24px auto; padding:0 var(--space)}
+.card{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); padding:calc(var(--space)*1.25)}
+.btn{display:inline-flex; align-items:center; gap:.5rem; padding:.6rem 1rem; border-radius:10px; border:1px solid var(--border); background:#0e223d}
+.btn:hover{filter:brightness(1.1)}
+.table-wrap{overflow:auto; border:1px solid var(--border); border-radius:var(--radius)}
+.table{width:100%; border-collapse:collapse}
+.table th,.table td{padding:.7rem 1rem; border-bottom:1px solid var(--border)}
+.page-header{display:flex; align-items:center; justify-content:space-between; margin-bottom:1rem}
+.empty{padding:2rem; border:1px dashed var(--border); border-radius:var(--radius); color:var(--muted); background:rgba(15,23,42,.35)}
+.hint{color:var(--muted)}
+:focus{outline:2px solid var(--accent); outline-offset:2px}

--- a/examgen_web/templates/base.html
+++ b/examgen_web/templates/base.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}ExamGen{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}" />
+  </head>
+  <body>
+  <nav class="topbar" role="navigation">
+    <div class="brand"><a href="/">ExamGen</a></div>
+    <ul class="menu">
+      <li><a href="/">Inicio</a></li>
+      <li><a href="/exams">Exámenes</a></li>
+      <li><a href="/import">Importar</a></li>
+      <li><a href="/settings">Ajustes</a></li>
+    </ul>
+  </nav>
+  {% block content %}{% endblock %}
+  </body>
+</html>

--- a/examgen_web/templates/exams/list.html
+++ b/examgen_web/templates/exams/list.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Exámenes · ExamGen{% endblock %}
+{% block content %}
+<section class="container">
+  <header class="page-header">
+    <h1>Exámenes</h1>
+    <div class="actions">
+      <a class="btn" href="/exams/exams.csv">CSV</a>
+      <a class="btn" href="/exams/exams.json">JSON</a>
+    </div>
+  </header>
+
+  {% if not items %}
+    <div class="empty">
+      <p>No se detectaron exámenes aún.</p>
+      <p class="hint">Puedes <a href="/import">importar</a> un banco o crear uno desde “Crear examen”.</p>
+    </div>
+  {% else %}
+    <div class="table-wrap">
+      <table class="table">
+        <thead><tr><th>ID</th><th>Título</th></tr></thead>
+        <tbody>
+          {% for e in items %}
+            <tr>
+              <td>{{ e.id }}</td>
+              <td>{{ e.title or "—" }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/examgen_web/templates/index.html
+++ b/examgen_web/templates/index.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Inicio · ExamGen{% endblock %}
+{% block content %}
+<section class="container">
+  <div class="card">
+    <h1>ExamGen</h1>
+    <a class="btn" href="/exams">Ver exámenes</a>
+  </div>
+</section>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django>=4.2,<4.3
 djangorestframework>=3.15
 drf-yasg>=1.21
 django-cors-headers>=4.3
+flask>=3.0
 python-dotenv>=1.0
 pyside6>=6.8.3,<6.10
 qt6-tools>=6.5,<6.10

--- a/tests/test_web_exams_smoke.py
+++ b/tests/test_web_exams_smoke.py
@@ -1,0 +1,26 @@
+import pytest
+from examgen_web.app import create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.testing = True
+    return app.test_client()
+
+
+def test_list_exams(client):
+    resp = client.get("/exams")
+    assert resp.status_code == 200
+
+
+def test_export_json(client):
+    resp = client.get("/exams/exams.json")
+    assert resp.status_code == 200
+    assert resp.mimetype.startswith("application/json")
+
+
+def test_export_csv(client):
+    resp = client.get("/exams/exams.csv")
+    assert resp.status_code == 200
+    assert "text/csv" in resp.mimetype


### PR DESCRIPTION
## Summary
- add Flask web app with exams blueprint and navigation
- expose CSV/JSON exam exports and basic templates/CSS
- add smoke tests for /exams endpoints

## Testing
- `flake8 src/ tests/` *(fails: many existing style errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8a192c1c83298fc1ebd93cf2459a