### PR TITLE
feat(EXG-7.2): historial de exámenes (intentos/resultados) + export CSV/JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ cython_debug/
 *.db
 **/__pycache__/
 *.log
+logs/

--- a/examgen_web/app.py
+++ b/examgen_web/app.py
@@ -1,10 +1,12 @@
 from flask import Flask
 from .blueprints.exams import bp as exams_bp
+from .blueprints.attempts import bp as attempts_bp
 
 
 def create_app() -> Flask:
     app = Flask(__name__, static_folder="static", template_folder="templates")
-    # Navegación sin barra final y registro del blueprint de exámenes
+    # Navegación sin barra final y registro de blueprints
     app.url_map.strict_slashes = False
     app.register_blueprint(exams_bp, url_prefix="/exams")
+    app.register_blueprint(attempts_bp, url_prefix="/attempts")
     return app

--- a/examgen_web/blueprints/attempts.py
+++ b/examgen_web/blueprints/attempts.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from typing import Any, Dict, Iterable, List
+
+from flask import (
+    Blueprint,
+    Response,
+    render_template,
+    request,
+    stream_with_context,
+)
+
+from ..utils.audit import append_event
+
+bp = Blueprint("attempts", __name__)
+
+
+# --- Helpers ---
+
+def _db_path_from_url(url: str) -> str:
+    if not url or not url.startswith("sqlite"):
+        return "./examgen.db"
+    return url.split("///", 1)[-1]
+
+
+def _detect_attempts_table(conn: sqlite3.Connection) -> Dict[str, Any] | None:
+    candidates = [
+        "attempts",
+        "exam_attempts",
+        "results",
+        "submissions",
+        "exam_results",
+    ]
+    tables = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    matches: List[Dict[str, Any]] = []
+    for (tname,) in tables:
+        if tname.lower() not in candidates:
+            continue
+        cols = conn.execute(f"PRAGMA table_info('{tname}')").fetchall()
+        colnames = {c[1].lower() for c in cols}
+        score = 0
+        for c in ("id", "exam_id", "score", "status"):
+            if c in colnames:
+                score += 1
+        for c in (
+            "started_at",
+            "started",
+            "start_time",
+            "created_at",
+            "created",
+        ):
+            if c in colnames:
+                score += 1
+        for c in (
+            "submitted_at",
+            "finished_at",
+            "completed_at",
+            "end_time",
+            "updated_at",
+            "updated",
+        ):
+            if c in colnames:
+                score += 1
+        matches.append({"name": tname, "cols": colnames, "score": score})
+    if not matches:
+        return None
+    matches.sort(key=lambda m: m["score"], reverse=True)
+    return matches[0]
+
+
+def _detect_exams_table(conn: sqlite3.Connection) -> Dict[str, Any] | None:
+    for tname in ("exams", "exam", "exam_bank"):
+        cols = conn.execute(f"PRAGMA table_info('{tname}')").fetchall()
+        if not cols:
+            continue
+        colnames = {c[1].lower() for c in cols}
+        if "id" in colnames and ("title" in colnames or "name" in colnames):
+            return {"name": tname, "cols": colnames}
+    return None
+
+
+def _list_attempts_fallback(
+    exam_id: int | None = None, limit: int = 200
+) -> List[Dict[str, Any]]:
+    url = os.getenv("EXAMGEN_DB_URL", "sqlite:///./examgen.db")
+    path = _db_path_from_url(url)
+    if not os.path.exists(path):
+        return []
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        meta = _detect_attempts_table(conn)
+        if not meta:
+            return []
+        t = meta["name"]
+        cols = meta["cols"]
+        select_cols: List[str] = []
+        if "id" in cols:
+            select_cols.append(f"{t}.id AS attempt_id")
+        if "exam_id" in cols:
+            select_cols.append(f"{t}.exam_id AS exam_id")
+        start_col = next(
+            (
+                c
+                for c in (
+                    "started_at",
+                    "started",
+                    "start_time",
+                    "created_at",
+                    "created",
+                )
+                if c in cols
+            ),
+            None,
+        )
+        if start_col:
+            select_cols.append(f"{t}.{start_col} AS started_at")
+        end_col = next(
+            (
+                c
+                for c in (
+                    "submitted_at",
+                    "finished_at",
+                    "completed_at",
+                    "end_time",
+                    "updated_at",
+                    "updated",
+                )
+                if c in cols
+            ),
+            None,
+        )
+        if end_col:
+            select_cols.append(f"{t}.{end_col} AS submitted_at")
+        if "score" in cols:
+            select_cols.append(f"{t}.score AS score")
+        if "status" in cols:
+            select_cols.append(f"{t}.status AS status")
+        join = ""
+        exams_meta = _detect_exams_table(conn)
+        if exams_meta and "exam_id" in cols:
+            et = exams_meta["name"]
+            ecols = exams_meta["cols"]
+            title_col = "title" if "title" in ecols else "name"
+            select_cols.append(f"{et}.{title_col} AS exam_title")
+            join = f" LEFT JOIN {et} ON {t}.exam_id = {et}.id"
+        if not select_cols:
+            return []
+        sql = f"SELECT {', '.join(select_cols)} FROM {t}{join}"
+        params: List[Any] = []
+        where: List[str] = []
+        if exam_id is not None and "exam_id" in cols:
+            where.append(f"{t}.exam_id = ?")
+            params.append(exam_id)
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        order_col = "started_at" if start_col else None
+        if order_col is None and end_col:
+            order_col = "submitted_at"
+        if order_col:
+            sql += f" ORDER BY {order_col} DESC"
+        elif "id" in cols:
+            sql += f" ORDER BY {t}.id DESC"
+        sql += " LIMIT ?"
+        params.append(limit)
+        rows = conn.execute(sql, params).fetchall()
+        data: List[Dict[str, Any]] = []
+        for r in rows:
+            d = dict(r)
+            data.append(
+                {
+                    "attempt_id": d.get("attempt_id"),
+                    "exam_id": d.get("exam_id"),
+                    "exam_title": d.get("exam_title"),
+                    "started_at": d.get("started_at"),
+                    "submitted_at": d.get("submitted_at"),
+                    "score": d.get("score"),
+                    "status": d.get("status"),
+                    "raw": d,
+                }
+            )
+        return data
+    finally:
+        conn.close()
+
+
+def list_attempts(
+    exam_id: int | None = None, limit: int = 200
+) -> List[Dict[str, Any]]:
+    try:
+        from src.examgen.core.services import exam_service  # type: ignore
+
+        return exam_service.list_attempts(exam_id=exam_id, limit=limit)
+    except Exception:
+        return _list_attempts_fallback(exam_id=exam_id, limit=limit)
+
+
+# --- Routes ---
+
+@bp.get("/")
+def attempts_index() -> str:
+    exam_id = request.args.get("exam_id", type=int)
+    items = list_attempts(exam_id=exam_id)
+    append_event(
+        "attempts.viewed",
+        route=request.path,
+        exam_id=exam_id,
+        count=len(items),
+    )
+    return render_template("attempts/list.html", items=items, exam_id=exam_id)
+
+
+def _stream_json(items: Iterable[Dict[str, Any]]) -> Iterable[str]:
+    yield "["
+    first = True
+    for it in items:
+        if not first:
+            yield ","
+        yield json.dumps(it["raw"], ensure_ascii=False)
+        first = False
+    yield "]"
+
+
+@bp.get("/attempts.json")
+def export_json() -> Response:
+    exam_id = request.args.get("exam_id", type=int)
+    items = list_attempts(exam_id=exam_id, limit=10000)
+    append_event(
+        "attempts.exported",
+        route=request.path,
+        exam_id=exam_id,
+        count=len(items),
+    )
+    return Response(
+        stream_with_context(_stream_json(items)),
+        mimetype="application/json",
+    )
+
+
+def _stream_csv(items: Iterable[Dict[str, Any]]) -> Iterable[str]:
+    it = list(items)
+    if not it:
+        yield ""
+        return
+    headers = list(it[0]["raw"].keys())
+    yield ",".join(headers) + "\n"
+    for row in it:
+        vals = [str(row["raw"].get(h, "")) for h in headers]
+        yield ",".join(vals) + "\n"
+
+
+@bp.get("/attempts.csv")
+def export_csv() -> Response:
+    exam_id = request.args.get("exam_id", type=int)
+    items = list_attempts(exam_id=exam_id, limit=10000)
+    append_event(
+        "attempts.exported",
+        route=request.path,
+        exam_id=exam_id,
+        count=len(items),
+    )
+    return Response(
+        stream_with_context(_stream_csv(items)),
+        mimetype="text/csv; charset=utf-8",
+    )

--- a/examgen_web/templates/attempts/list.html
+++ b/examgen_web/templates/attempts/list.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block title %}Historial de exámenes · ExamGen{% endblock %}
+{% block content %}
+<section class="container">
+  <header class="page-header">
+    <h1>Historial de exámenes</h1>
+    <div class="actions">
+      <a class="btn" href="{{ url_for('attempts.export_csv', exam_id=exam_id) }}">CSV</a>
+      <a class="btn" href="{{ url_for('attempts.export_json', exam_id=exam_id) }}">JSON</a>
+    </div>
+  </header>
+
+  {% if exam_id %}
+    <p class="hint">Filtrado por examen #{{ exam_id }}.
+      <a href="{{ url_for('attempts.attempts_index') }}">Quitar filtro</a>
+    </p>
+  {% endif %}
+
+  {% if not items %}
+    <div class="empty">
+      <p>No se encontraron intentos.</p>
+      <p class="hint">Puedes <a href="/import">importar</a> un banco para comenzar.</p>
+    </div>
+  {% else %}
+    <div class="table-wrap">
+      <table class="table" role="table">
+        <thead>
+          <tr>
+            <th scope="col">Intento</th>
+            <th scope="col">Examen</th>
+            <th scope="col">Inicio</th>
+            <th scope="col">Fin</th>
+            <th scope="col">Puntuación</th>
+            <th scope="col">Estado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for a in items %}
+          <tr>
+            <td>{{ a.attempt_id }}</td>
+            <td>{{ a.exam_title or ('#' ~ a.exam_id) }}</td>
+            <td>{{ a.started_at or '—' }}</td>
+            <td>{{ a.submitted_at or '—' }}</td>
+            <td>{{ a.score if a.score is not none else '—' }}</td>
+            <td>{{ a.status or '—' }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/examgen_web/templates/base.html
+++ b/examgen_web/templates/base.html
@@ -11,6 +11,7 @@
     <ul class="menu">
       <li><a href="/">Inicio</a></li>
       <li><a href="/exams">Exámenes</a></li>
+      <li><a href="/attempts">Historial</a></li>
       <li><a href="/import">Importar</a></li>
       <li><a href="/settings">Ajustes</a></li>
     </ul>

--- a/examgen_web/templates/exams/list.html
+++ b/examgen_web/templates/exams/list.html
@@ -18,12 +18,13 @@
   {% else %}
     <div class="table-wrap">
       <table class="table">
-        <thead><tr><th>ID</th><th>Título</th></tr></thead>
+        <thead><tr><th>ID</th><th>Título</th><th>Historial</th></tr></thead>
         <tbody>
           {% for e in items %}
             <tr>
               <td>{{ e.id }}</td>
               <td>{{ e.title or "—" }}</td>
+              <td><a class="btn" href="{{ url_for('attempts.attempts_index', exam_id=e.id) }}">Historial</a></td>
             </tr>
           {% endfor %}
         </tbody>

--- a/examgen_web/utils/__init__.py
+++ b/examgen_web/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utilidades para la aplicación web de ExamGen."""
+
+from .audit import append_event
+
+__all__ = ["append_event"]

--- a/examgen_web/utils/audit.py
+++ b/examgen_web/utils/audit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def append_event(event: str, **data: Any) -> None:
+    """Append an event to ``logs/web_events.jsonl``.
+
+    Parameters
+    ----------
+    event:
+        Nombre del evento.
+    data:
+        Datos adicionales serializables.
+    """
+    log_path = Path("logs/web_events.jsonl")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"event": event, "ts": datetime.utcnow().isoformat(), **data}
+    with log_path.open("a", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False)
+        fh.write("\n")

--- a/tests/test_web_attempts_smoke.py
+++ b/tests/test_web_attempts_smoke.py
@@ -1,0 +1,31 @@
+import pytest
+from examgen_web.app import create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.testing = True
+    return app.test_client()
+
+
+def test_list_attempts(client):
+    resp = client.get("/attempts")
+    assert resp.status_code == 200
+
+
+def test_filter_exam(client):
+    resp = client.get("/attempts?exam_id=1")
+    assert resp.status_code == 200
+
+
+def test_export_json(client):
+    resp = client.get("/attempts/attempts.json")
+    assert resp.status_code == 200
+    assert resp.mimetype.startswith("application/json")
+
+
+def test_export_csv(client):
+    resp = client.get("/attempts/attempts.csv")
+    assert resp.status_code == 200
+    assert "text/csv" in resp.mimetype


### PR DESCRIPTION
## Summary
- add attempts blueprint with SSR list, streaming exports and audit logging
- expose attempts history in navbar and exam list
- smoke tests for attempts endpoints

## Testing
- `flake8 examgen_web/blueprints/attempts.py examgen_web/utils/audit.py tests/test_web_attempts_smoke.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a03e3d77bc8329947114f20a5968d8