### PR TITLE
feat(EXG-7.4): mejorar importación con preview y mapeo de columnas

### DIFF
--- a/examgen_web/app.py
+++ b/examgen_web/app.py
@@ -2,14 +2,17 @@ from flask import Flask
 from .blueprints.exams import bp as exams_bp
 from .blueprints.attempts import bp as attempts_bp
 from .blueprints.player import bp as player_bp
+from .blueprints.importer import bp as importer_bp
 
 
 def create_app() -> Flask:
     app = Flask(__name__, static_folder="static", template_folder="templates")
     app.secret_key = "dev"
+    app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024
     # Navegación sin barra final y registro de blueprints
     app.url_map.strict_slashes = False
     app.register_blueprint(exams_bp, url_prefix="/exams")
     app.register_blueprint(attempts_bp, url_prefix="/attempts")
     app.register_blueprint(player_bp)
+    app.register_blueprint(importer_bp, url_prefix="/import")
     return app

--- a/examgen_web/blueprints/importer.py
+++ b/examgen_web/blueprints/importer.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterator, List
+
+from flask import (
+    Blueprint,
+    Response,
+    redirect,
+    render_template,
+    request,
+    session,
+    stream_with_context,
+    url_for,
+)
+
+from examgen.core import models as m
+from examgen.core.database import SessionLocal
+from examgen_web.utils import import_utils
+from examgen_web.utils.audit import append_event
+
+bp = Blueprint("importer", __name__)
+LAST_REPORT: Dict[str, Any] | None = None
+
+
+@bp.get("/")
+def upload_form() -> str:
+    with SessionLocal() as s:
+        has_subjects = s.query(m.Subject).count() > 0
+        has_questions = s.query(m.Question).count() > 0
+    empty_db = not (has_subjects and has_questions)
+    return render_template("import/upload.html", empty_db=empty_db)
+
+
+@bp.post("/upload")
+def upload_file() -> str:
+    file = request.files.get("file")
+    if file is None or file.filename == "":
+        return (
+            render_template("import/upload.html", error="Archivo requerido"),
+            400,
+        )
+    content = file.read()
+    if len(content) > 10 * 1024 * 1024:
+        return (
+            render_template("import/upload.html", error="Archivo supera 10MB"),
+            400,
+        )
+    fmt = import_utils.detect_format(file.filename, content[:100])
+    headers, preview_rows = import_utils.parse_data(content, fmt, limit=25)
+    _, all_rows = import_utils.parse_data(content, fmt, limit=None)
+    session["import_data"] = {
+        "file_name": file.filename,
+        "rows": all_rows,
+        "headers": headers,
+        "format": fmt,
+    }
+    return render_template(
+        "import/preview.html",
+        headers=headers,
+        rows=preview_rows,
+        fields=import_utils.EXPECTED_FIELDS,
+    )
+
+
+@bp.post("/confirm")
+def confirm_import() -> str:
+    data = session.get("import_data")
+    if not data:
+        return redirect(url_for("importer.upload_form"))
+    rows = data["rows"]
+    headers = data["headers"]
+    mapping: Dict[str, str] = {}
+    for h in headers:
+        field = request.form.get(f"map-{h}")
+        if field:
+            mapping[h] = field
+    selected = [int(idx) for idx in request.form.getlist("row")]
+    summary = {
+        "file_name": data["file_name"],
+        "rows_total": len(selected),
+        "imported": 0,
+        "duplicates": 0,
+        "skipped": 0,
+        "rows": [],
+    }
+    with SessionLocal() as db:
+        for idx in selected:
+            raw = rows[idx]
+            mapped = {mapping[h]: raw.get(h) for h in mapping}
+            mapped = import_utils.normalise(mapped)
+            subject_name = mapped.get("subject")
+            prompt = mapped.get("prompt")
+            if not subject_name or not prompt:
+                summary["skipped"] += 1
+                summary["rows"].append({"row": idx, "status": "skipped"})
+                continue
+            if import_utils.is_duplicate(db, subject_name, prompt):
+                summary["duplicates"] += 1
+                summary["rows"].append({"row": idx, "status": "duplicate"})
+                continue
+            subj = (
+                db.query(m.Subject)
+                .filter_by(name=subject_name)
+                .one_or_none()
+            )
+            if not subj:
+                subj = m.Subject(name=subject_name)
+                db.add(subj)
+                db.flush()
+            question = m.MCQQuestion(
+                prompt=prompt,
+                explanation=mapped.get("explanation"),
+                subject_id=subj.id,
+                meta=mapped.get("meta") or {},
+            )
+            options: List[m.AnswerOption] = []
+            correct = str(mapped.get("correct") or "").strip()
+            for i in range(1, 6):
+                text = mapped.get(f"option_{i}")
+                if not text:
+                    continue
+                is_correct = (
+                    correct == str(i) or correct.lower() == text.lower()
+                )
+                options.append(
+                    m.AnswerOption(text=text, is_correct=is_correct)
+                )
+            if not options:
+                summary["skipped"] += 1
+                summary["rows"].append({"row": idx, "status": "skipped"})
+                continue
+            question.options = options
+            db.add(question)
+            summary["imported"] += 1
+            summary["rows"].append({"row": idx, "status": "imported"})
+        db.commit()
+    global LAST_REPORT
+    LAST_REPORT = summary
+    append_event(
+        "import.completed",
+        file_name=summary["file_name"],
+        rows_total=summary["rows_total"],
+        imported=summary["imported"],
+        duplicates=summary["duplicates"],
+        skipped=summary["skipped"],
+    )
+    return render_template("import/result.html", summary=summary)
+
+
+@bp.get("/report.json")
+def report_json() -> Response:
+    if LAST_REPORT is None:
+        return Response("{}", status=404, mimetype="application/json")
+    return Response(
+        json.dumps(LAST_REPORT, ensure_ascii=False),
+        mimetype="application/json",
+    )
+
+
+@bp.get("/report.csv")
+def report_csv() -> Response:
+    if LAST_REPORT is None:
+        return Response("", status=404, mimetype="text/csv")
+
+    def generate() -> Iterator[str]:
+        yield "row,status\n"
+        for r in LAST_REPORT["rows"]:
+            yield f"{r['row']},{r['status']}\n"
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="text/csv; charset=utf-8",
+    )

--- a/examgen_web/static/import.js
+++ b/examgen_web/static/import.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('select.col-map').forEach((sel) => {
+    sel.addEventListener('change', () => {
+      const target = document.getElementById(sel.dataset.target);
+      if (target) {
+        target.textContent = sel.value || target.dataset.original;
+      }
+    });
+  });
+});

--- a/examgen_web/templates/base.html
+++ b/examgen_web/templates/base.html
@@ -12,7 +12,7 @@
       <li><a href="/">Inicio</a></li>
       <li><a href="/exams">Exámenes</a></li>
       <li><a href="/attempts">Historial</a></li>
-      <li><a href="/import">Importar</a></li>
+      <li class="{% if request.path.startswith('/import') %}active{% endif %}"><a href="/import">Importar</a></li>
       <li><a href="/settings">Ajustes</a></li>
     </ul>
   </nav>

--- a/examgen_web/templates/import/preview.html
+++ b/examgen_web/templates/import/preview.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Previsualizar importación</h1>
+<form action="{{ url_for('importer.confirm_import') }}" method="post">
+<div class="table-wrap">
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      {% for h in headers %}
+        <th>
+          <select name="map-{{ h }}" class="col-map" data-target="col-{{ loop.index0 }}">
+            <option value=""></option>
+            {% for field in fields %}
+              <option value="{{ field }}" {% if h|lower == field %}selected{% endif %}>{{ field }}</option>
+            {% endfor %}
+          </select>
+        </th>
+      {% endfor %}
+    </tr>
+    <tr>
+      <th>Importar</th>
+      {% for h in headers %}
+        <th id="col-{{ loop.index0 }}" data-original="{{ h }}">{{ h }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <td><input type="checkbox" name="row" value="{{ loop.index0 }}" checked></td>
+      {% for h in headers %}
+        <td>{{ row.get(h, '') }}</td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>
+<button class="btn" type="submit">Confirmar importación</button>
+<a class="btn" href="{{ url_for('importer.upload_form') }}">Cancelar</a>
+</form>
+<script src="{{ url_for('static', filename='import.js') }}"></script>
+{% endblock %}

--- a/examgen_web/templates/import/result.html
+++ b/examgen_web/templates/import/result.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Importación completada</h1>
+<p>Archivo: {{ summary.file_name }}</p>
+<ul>
+  <li>Filas procesadas: {{ summary.rows_total }}</li>
+  <li>Insertadas: {{ summary.imported }}</li>
+  <li>Duplicadas: {{ summary.duplicates }}</li>
+  <li>Omitidas: {{ summary.skipped }}</li>
+</ul>
+<p><a class="btn" href="{{ url_for('importer.report_json') }}">Reporte JSON</a>
+<a class="btn" href="{{ url_for('importer.report_csv') }}">Reporte CSV</a></p>
+<a class="btn" href="/">Volver</a>
+{% endblock %}

--- a/examgen_web/templates/import/upload.html
+++ b/examgen_web/templates/import/upload.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Importar preguntas</h1>
+{% if empty_db %}
+<p class="warning">La base de datos está vacía. Considera hacer un backup.</p>
+{% endif %}
+{% if error %}
+<p class="error">{{ error }}</p>
+{% endif %}
+<form action="{{ url_for('importer.upload_file') }}" method="post" enctype="multipart/form-data">
+  <p>
+    <input type="file" name="file" required />
+  </p>
+  <p>
+    <label>Tipo de archivo
+      <select name="kind">
+        <option value="auto">Auto</option>
+        <option value="csv">CSV</option>
+        <option value="json">JSON</option>
+      </select>
+    </label>
+  </p>
+  <button class="btn" type="submit">Cargar</button>
+</form>
+{% endblock %}

--- a/examgen_web/templates/settings.html
+++ b/examgen_web/templates/settings.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Ajustes</h1>
+<p>Antes de importar, recuerda realizar un <strong>backup</strong> de tu base de datos.</p>
+{% endblock %}

--- a/examgen_web/utils/import_utils.py
+++ b/examgen_web/utils/import_utils.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Any, List
+
+from sqlalchemy.orm import Session
+
+from examgen.core import models as m
+
+MAX_PREVIEW_ROWS = 25
+EXPECTED_FIELDS: List[str] = [
+    "subject",
+    "prompt",
+    "option_1",
+    "option_2",
+    "option_3",
+    "option_4",
+    "option_5",
+    "correct",
+    "explanation",
+    "meta",
+]
+
+
+def detect_format(filename: str, snippet: bytes) -> str:
+    """Return ``'json'`` or ``'csv'`` based on name or content."""
+    name = filename.lower()
+    if name.endswith(".json"):
+        return "json"
+    if name.endswith(".csv"):
+        return "csv"
+    snippet = snippet.lstrip()
+    if snippet.startswith(b"[") or snippet.startswith(b"{"):
+        return "json"
+    return "csv"
+
+
+def parse_data(
+    data: bytes, fmt: str, limit: int | None = None
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Parse bytes ``data`` as CSV/JSON returning headers and rows."""
+    if fmt == "json":
+        items = json.loads(data.decode("utf-8"))
+        if isinstance(items, dict):
+            items = [items]
+        rows = list(items if limit is None else items[:limit])
+        headers = list(rows[0].keys()) if rows else []
+        return headers, rows
+    # CSV branch
+    fh = io.StringIO(data.decode("utf-8"))
+    reader = csv.DictReader(fh)
+    headers = reader.fieldnames or []
+    rows: list[dict[str, Any]] = []
+    for i, row in enumerate(reader):
+        if limit is not None and i >= limit:
+            break
+        rows.append(row)
+    if limit is None:
+        # read remaining rows
+        rows.extend(row for row in reader)
+    return headers, rows
+
+
+def normalise(row: dict[str, Any]) -> dict[str, Any]:
+    """Trim strings, convert blanks to ``None`` and load meta JSON."""
+    clean: dict[str, Any] = {}
+    for key, value in row.items():
+        if isinstance(value, str):
+            value = value.strip()
+        if value == "":
+            value = None
+        clean[key] = value
+    meta = clean.get("meta")
+    if isinstance(meta, str):
+        try:
+            clean["meta"] = json.loads(meta)
+        except json.JSONDecodeError:
+            clean["meta"] = {}
+    return clean
+
+
+def is_duplicate(session: Session, subject: str, prompt: str) -> bool:
+    """Return ``True`` if a question with same subject & prompt exists."""
+    subj = session.query(m.Subject).filter_by(name=subject).one_or_none()
+    if not subj:
+        return False
+    return (
+        session.query(m.Question)
+        .filter_by(subject_id=subj.id, prompt=prompt)
+        .first()
+        is not None
+    )


### PR DESCRIPTION
## Summary
- add importer blueprint for CSV/JSON uploads with preview, mapping and summary reporting
- add parsing utilities, templates and JS for interactive mapping
- highlight Importar menu and warn about backups in settings

## Testing
- `flake8 examgen_web src tests` *(fails: numerous pre-existing style errors)*
- `flake8 examgen_web/blueprints/importer.py examgen_web/utils/import_utils.py examgen_web/app.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a050df25a88329a325219d1d85aea3