### PR TITLE
feat(web): add question cloning and versioning

### DIFF
--- a/examgen_web/app.py
+++ b/examgen_web/app.py
@@ -3,6 +3,7 @@ from .blueprints.exams import bp as exams_bp
 from .blueprints.attempts import bp as attempts_bp
 from .blueprints.player import bp as player_bp
 from .blueprints.settings import bp as settings_bp
+from .blueprints.clone import bp as questions_bp
 
 try:  # Importer blueprint may depend on optional packages
     from .blueprints.importer import bp as importer_bp
@@ -19,6 +20,7 @@ def create_app() -> Flask:
     app.register_blueprint(exams_bp, url_prefix="/exams")
     app.register_blueprint(attempts_bp, url_prefix="/attempts")
     app.register_blueprint(player_bp)
+    app.register_blueprint(questions_bp)
     if importer_bp is not None:
         app.register_blueprint(importer_bp, url_prefix="/import")
     app.register_blueprint(settings_bp, url_prefix="/settings")

--- a/examgen_web/blueprints/clone.py
+++ b/examgen_web/blueprints/clone.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from flask import (
+    Blueprint,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+# Dominio primero; si los modelos no están disponibles, fallback vacío
+try:  # pragma: no cover - se ejecuta en entornos sin el paquete
+    from examgen.core import models as m
+    from examgen.core.database import SessionLocal
+except Exception:  # pragma: no cover - entorno mínimo
+    m = None  # type: ignore
+    SessionLocal = None  # type: ignore
+
+from ..utils.clone_utils import _next_version, clone_question
+from ..utils.audit import log_question_cloned
+
+bp = Blueprint("questions", __name__)
+
+
+@bp.get("/questions")
+def list_questions() -> str:
+    if SessionLocal is None or m is None:
+        items: list[Any] = []
+    else:
+        with SessionLocal() as s:
+            items = (
+                s.query(m.MCQQuestion)
+                .order_by(m.MCQQuestion.id.desc())
+                .all()
+            )
+    return render_template("questions/list.html", items=items)
+
+
+@bp.get("/questions/<int:qid>")
+def question_detail(qid: int) -> str:
+    if SessionLocal is None or m is None:
+        return "Pregunta no disponible", 404
+    with SessionLocal() as s:
+        q = s.get(m.MCQQuestion, qid)
+        if not q:
+            return "Pregunta no encontrada", 404
+        derived = (
+            s.query(m.MCQQuestion)
+            .filter(m.MCQQuestion.meta["cloned_from"].as_integer() == qid)
+            .all()
+        )
+    return render_template(
+        "questions/detail.html", question=q, derived=derived
+    )
+
+
+@bp.get("/questions/<int:qid>/clone")
+def clone_form(qid: int) -> str:
+    if SessionLocal is None or m is None:
+        return "Pregunta no disponible", 404
+    with SessionLocal() as s:
+        q = s.get(m.MCQQuestion, qid)
+        if not q:
+            return "Pregunta no encontrada", 404
+        subjects = (
+            s.query(m.Subject).order_by(m.Subject.name).all()
+        )
+    version = _next_version(q.meta.get("version"))
+    return render_template(
+        "questions/clone.html",
+        question=q,
+        subjects=subjects,
+        version=version,
+    )
+
+
+@bp.post("/questions/<int:qid>/clone")
+def clone_post(qid: int):
+    if SessionLocal is None or m is None:
+        return "Pregunta no disponible", 404
+    form = request.form
+    with SessionLocal() as s:
+        original = s.get(m.MCQQuestion, qid)
+        if not original:
+            return "Pregunta no encontrada", 404
+        count = int(form.get("options_count", 0))
+        options: List[Dict[str, Any]] = []
+        for idx in range(count):
+            options.append(
+                {
+                    "text": form.get(f"option_text_{idx}", ""),
+                    "is_correct": form.get(f"option_correct_{idx}") == "on",
+                    "answer": form.get(f"option_answer_{idx}") or None,
+                    "explanation": form.get(
+                        f"option_explanation_{idx}") or None,
+                }
+            )
+        try:
+            meta = json.loads(form.get("meta", "{}"))
+        except json.JSONDecodeError:
+            meta = {}
+        overrides = {
+            "prompt": form.get("prompt", ""),
+            "explanation": form.get("explanation") or None,
+            "difficulty": int(form.get("difficulty", original.difficulty)),
+            "subject_id": int(form.get("subject_id", original.subject_id)),
+            "version": form.get("version"),
+            "meta": meta,
+            "options": options,
+        }
+        new_q, changes = clone_question(s, original, overrides)
+        s.commit()
+    user = session.get("user")
+    log_question_cloned(qid, new_q.id, user=user, changes=changes)
+    return redirect(url_for("questions.question_detail", qid=new_q.id))

--- a/examgen_web/templates/questions/clone.html
+++ b/examgen_web/templates/questions/clone.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Clonar pregunta{% endblock %}
+{% block content %}
+<h1>Clonar pregunta #{{ question.id }}</h1>
+<form method="post">
+  <label for="prompt">Enunciado</label><br />
+  <textarea id="prompt" name="prompt" rows="4" cols="80">{{ question.prompt }}</textarea><br />
+
+  <label for="explanation">Explicación</label><br />
+  <textarea id="explanation" name="explanation" rows="3" cols="80">{{ question.explanation or '' }}</textarea><br />
+
+  <label for="subject_id">Materia</label>
+  <select id="subject_id" name="subject_id">
+    {% for subj in subjects %}
+      <option value="{{ subj.id }}" {% if subj.id == question.subject_id %}selected{% endif %}>{{ subj.name }}</option>
+    {% endfor %}
+  </select><br />
+
+  <label for="difficulty">Dificultad</label>
+  <input id="difficulty" type="number" name="difficulty" value="{{ question.difficulty }}" /><br />
+
+  <label for="version">Versión</label>
+  <input id="version" type="text" name="version" value="{{ version }}" /><br />
+
+  <label for="meta">Meta</label><br />
+  <textarea id="meta" name="meta" rows="4" cols="80">{{ question.meta | tojson }}</textarea><br />
+
+  <h2>Opciones</h2>
+  {% for opt in question.options %}
+    <div class="option">
+      <input type="text" name="option_text_{{ loop.index0 }}" value="{{ opt.text }}" />
+      <label>
+        <input type="checkbox" name="option_correct_{{ loop.index0 }}" {% if opt.is_correct %}checked{% endif %} /> Correcta
+      </label>
+      <input type="text" name="option_answer_{{ loop.index0 }}" value="{{ opt.answer or '' }}" placeholder="Respuesta" />
+      <input type="text" name="option_explanation_{{ loop.index0 }}" value="{{ opt.explanation or '' }}" placeholder="Explicación" />
+    </div>
+  {% endfor %}
+  <input type="hidden" name="options_count" value="{{ question.options|length }}" />
+  <button type="submit">Guardar copia</button>
+</form>
+{% endblock %}

--- a/examgen_web/templates/questions/detail.html
+++ b/examgen_web/templates/questions/detail.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Pregunta {{ question.id }}{% endblock %}
+{% block content %}
+<h1>Pregunta #{{ question.id }}</h1>
+<p>{{ question.prompt }}</p>
+
+{% if question.meta.get('cloned_from') %}
+  <p>Origen: <a href="{{ url_for('questions.question_detail', qid=question.meta['cloned_from']) }}">Pregunta {{ question.meta['cloned_from'] }}</a></p>
+{% endif %}
+
+{% if derived %}
+  <h2>Copias derivadas</h2>
+  <ul>
+  {% for q in derived %}
+    <li><a href="{{ url_for('questions.question_detail', qid=q.id) }}">Pregunta {{ q.id }}</a></li>
+  {% endfor %}
+  </ul>
+{% endif %}
+{% endblock %}

--- a/examgen_web/templates/questions/list.html
+++ b/examgen_web/templates/questions/list.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Preguntas{% endblock %}
+{% block content %}
+<h1>Preguntas</h1>
+<table class="questions">
+  <tr><th>ID</th><th>Enunciado</th><th></th></tr>
+  {% for q in items %}
+    <tr>
+      <td><a href="{{ url_for('questions.question_detail', qid=q.id) }}">{{ q.id }}</a></td>
+      <td>
+        {{ q.prompt[:80] }}{% if q.meta.get('cloned_from') %}
+          <span class="copy-note">(copia de <a href="{{ url_for('questions.question_detail', qid=q.meta['cloned_from']) }}">#{{ q.meta['cloned_from'] }}</a>)</span>
+        {% endif %}
+      </td>
+      <td><a href="{{ url_for('questions.clone_form', qid=q.id) }}">Clonar</a></td>
+    </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/examgen_web/utils/__init__.py
+++ b/examgen_web/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utilidades para la aplicación web de ExamGen."""
 
-from .audit import append_event
+from .audit import append_event, log_question_cloned
 
-__all__ = ["append_event"]
+__all__ = ["append_event", "log_question_cloned"]

--- a/examgen_web/utils/audit.py
+++ b/examgen_web/utils/audit.py
@@ -22,3 +22,19 @@ def append_event(event: str, **data: Any) -> None:
     with log_path.open("a", encoding="utf-8") as fh:
         json.dump(payload, fh, ensure_ascii=False)
         fh.write("\n")
+
+
+def log_question_cloned(
+    original_id: int,
+    new_id: int,
+    user: str | None = None,
+    changes: dict | None = None,
+) -> None:
+    """Convenience wrapper for ``questions.cloned`` event."""
+    append_event(
+        "questions.cloned",
+        original_id=original_id,
+        new_id=new_id,
+        user=user,
+        changes=changes or {},
+    )

--- a/examgen_web/utils/clone_utils.py
+++ b/examgen_web/utils/clone_utils.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+"""Utilities for cloning `MCQQuestion` records."""
+
+from typing import Any, Dict, List, Tuple
+
+from sqlalchemy.orm import Session
+
+try:  # pragma: no cover - entornos sin el paquete principal
+    from examgen.core import models as m
+except Exception:  # pragma: no cover
+    m = None  # type: ignore
+
+
+# Fields considered when computing differences between questions
+_DIFF_FIELDS = ["prompt", "explanation", "difficulty", "subject_id"]
+
+
+def _next_version(current: str | None) -> str:
+    """Return next semantic version given ``current`` (e.g., v1 -> v2)."""
+    if not current:
+        return "v1"
+    try:
+        num = int(str(current).lstrip("v")) + 1
+    except Exception:
+        return str(current)
+    return f"v{num}"
+
+
+def clone_question(
+    session: Session, original: m.MCQQuestion, overrides: Dict[str, Any]
+) -> Tuple[m.MCQQuestion, Dict[str, Any]]:
+    """Clone ``original`` question applying ``overrides``.
+
+    Parameters
+    ----------
+    session:
+        Active SQLAlchemy session.
+    original:
+        Question to duplicate.
+    overrides:
+        Mapping with possible keys: ``prompt``, ``explanation``,
+        ``difficulty``, ``subject_id``, ``options`` (list), ``version`` and
+        ``meta`` (dict).
+
+    Returns
+    -------
+    Tuple with the new question and a summary of changes.
+    """
+
+    if m is None:
+        raise RuntimeError("Domain models not available")
+
+    meta = dict(original.meta or {})
+    meta.update(overrides.get("meta", {}))
+    meta["cloned_from"] = original.id
+    meta["version"] = overrides.get(
+        "version", _next_version(meta.get("version"))
+    )
+
+    new_q = m.MCQQuestion(
+        prompt=overrides.get("prompt", original.prompt),
+        explanation=overrides.get("explanation", original.explanation),
+        difficulty=overrides.get("difficulty", original.difficulty),
+        subject_id=overrides.get("subject_id", original.subject_id),
+        reference=original.reference,
+        section=original.section,
+        meta=meta,
+    )
+    session.add(new_q)
+
+    options: List[Dict[str, Any]] = overrides.get("options", [])
+    if not options:
+        options = [
+            {
+                "text": opt.text,
+                "is_correct": opt.is_correct,
+                "answer": opt.answer,
+                "explanation": opt.explanation,
+            }
+            for opt in original.options
+        ]
+    for opt_data in options:
+        new_q.options.append(
+            m.AnswerOption(
+                text=opt_data.get("text", ""),
+                is_correct=opt_data.get("is_correct", False),
+                answer=opt_data.get("answer"),
+                explanation=opt_data.get("explanation"),
+            )
+        )
+
+    session.flush()
+
+    # diff summary
+    changes: Dict[str, Any] = {}
+    for field in _DIFF_FIELDS:
+        old_val = getattr(original, field)
+        new_val = getattr(new_q, field)
+        if old_val != new_val:
+            changes[field] = {"from": old_val, "to": new_val}
+    if original.meta != meta:
+        changes["meta"] = {"from": original.meta, "to": meta}
+    for idx, (old_opt, new_opt) in enumerate(
+        zip(original.options, new_q.options)
+    ):
+        if (
+            old_opt.text != new_opt.text
+            or old_opt.is_correct != new_opt.is_correct
+        ):
+            changes.setdefault("options", []).append(
+                {
+                    "index": idx,
+                    "from": {
+                        "text": old_opt.text,
+                        "is_correct": old_opt.is_correct,
+                    },
+                    "to": {
+                        "text": new_opt.text,
+                        "is_correct": new_opt.is_correct,
+                    },
+                }
+            )
+
+    return new_q, changes


### PR DESCRIPTION
## Summary
- add blueprint and templates to clone questions with version metadata
- log `questions.cloned` audit events
- expose cloning utilities and register blueprint in app

## Testing
- `flake8 examgen_web/blueprints/clone.py examgen_web/utils/clone_utils.py examgen_web/utils/audit.py examgen_web/utils/__init__.py`
- `flake8 src/ tests/` *(fails: F811, E501, etc. in existing files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a066f982388329bbc225e0f9a3ed58