### PR TITLE
feat(web): add accessibility landmarks and tests

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,21 @@
+# Accessibility Guidelines
+
+This document summarizes patterns used in ExamGen to meet WCAG 2.1 AA.
+
+## Landmarks and Navigation
+- Use `nav` with `role="navigation"` and descriptive `aria-label`.
+- Provide a skip link at the top of every page pointing to `#main-content`.
+- Wrap page content in `<main id="main-content" tabindex="-1">`.
+
+## Focus and Keyboard
+- All interactive elements must be reachable via keyboard.
+- Visible focus is handled globally in `app.css` using the `:focus` selector.
+
+## Tables
+- Header cells use `scope="col"`.
+- Tables include a caption or `aria-label` describing their purpose.
+
+## Live Regions
+- Status updates are announced using the `#status` element with `aria-live="polite"`.
+
+These conventions should be followed when adding new templates or components.

--- a/examgen_web/static/app.css
+++ b/examgen_web/static/app.css
@@ -17,6 +17,9 @@ a:hover{text-decoration:underline}
 .card{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); padding:calc(var(--space)*1.25)}
 .btn{display:inline-flex; align-items:center; gap:.5rem; padding:.6rem 1rem; border-radius:10px; border:1px solid var(--border); background:#0e223d}
 .btn:hover{filter:brightness(1.1)}
+.btn-primary{background:#1d4ed8; color:#fff}
+.btn-secondary{background:#374151; color:#fff}
+.btn-primary:hover,.btn-secondary:hover{filter:brightness(1.1)}
 .table-wrap{overflow:auto; border:1px solid var(--border); border-radius:var(--radius)}
 .table{width:100%; border-collapse:collapse}
 .table th,.table td{padding:.7rem 1rem; border-bottom:1px solid var(--border)}
@@ -25,3 +28,6 @@ a:hover{text-decoration:underline}
 .hint{color:var(--muted)}
 .upload-form{margin-top:1rem}
 :focus{outline:2px solid var(--accent); outline-offset:2px}
+.skip-link{position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden}
+.skip-link:focus{position:static; width:auto; height:auto}
+.sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0}

--- a/examgen_web/templates/base.html
+++ b/examgen_web/templates/base.html
@@ -6,7 +6,8 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}" />
   </head>
   <body>
-  <nav class="topbar" role="navigation">
+  <a href="#main-content" class="skip-link">{{ _('Saltar al contenido principal') }}</a>
+  <nav class="topbar" role="navigation" aria-label="{{ _('Main navigation') }}">
     <div class="brand"><a href="/">{{ _('ExamGen') }}</a></div>
     <ul class="menu">
       <li><a href="/">{{ _('Inicio') }}</a></li>
@@ -17,6 +18,9 @@
       <li>{% include 'partials/language_selector.html' %}</li>
     </ul>
   </nav>
-  {% block content %}{% endblock %}
+  <main id="main-content" tabindex="-1">
+    <div id="status" class="sr-only" aria-live="polite"></div>
+    {% block content %}{% endblock %}
+  </main>
   </body>
 </html>

--- a/examgen_web/templates/exams/list.html
+++ b/examgen_web/templates/exams/list.html
@@ -17,15 +17,15 @@
     </div>
   {% else %}
     <div class="table-wrap">
-      <table class="table">
-        <thead><tr><th>{{ _('ID') }}</th><th>{{ _('Título') }}</th><th>{{ _('Resolver') }}</th><th>{{ _('Historial') }}</th></tr></thead>
+      <table class="table" aria-label="{{ _('Listado de exámenes') }}">
+        <thead><tr><th scope="col">{{ _('ID') }}</th><th scope="col">{{ _('Título') }}</th><th scope="col">{{ _('Resolver') }}</th><th scope="col">{{ _('Historial') }}</th></tr></thead>
         <tbody>
           {% for e in items %}
             <tr>
               <td>{{ e.id }}</td>
               <td>{{ e.title or "—" }}</td>
-              <td><a class="btn" href="/exams/{{ e.id }}/take">{{ _('Resolver') }}</a></td>
-              <td><a class="btn" href="{{ url_for('attempts.attempts_index', exam_id=e.id) }}">{{ _('Historial') }}</a></td>
+              <td><a class="btn btn-primary" href="/exams/{{ e.id }}/take">{{ _('Resolver') }}</a></td>
+              <td><a class="btn btn-secondary" href="{{ url_for('attempts.attempts_index', exam_id=e.id) }}">{{ _('Historial') }}</a></td>
             </tr>
           {% endfor %}
         </tbody>

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,6 @@ faker>=25.2
 flake8>=7.0
 platformdirs>=4.0
 psutil>=5.9
+beautifulsoup4>=4.12
 
 

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,0 +1,28 @@
+import pytest
+from bs4 import BeautifulSoup
+from examgen_web.app import create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.testing = True
+    return app.test_client()
+
+
+def test_base_has_live_region(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+    status = soup.select_one("#status[aria-live='polite']")
+    assert status is not None
+
+
+def test_exams_headers_have_scope(client):
+    resp = client.get("/exams")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+    ths = soup.select("table thead th")
+    assert ths, "expected table headers"
+    for th in ths:
+        assert th.get("scope") == "col"


### PR DESCRIPTION
## Summary
- document accessibility conventions
- add skip links, live region, and ARIA attributes
- introduce smoke tests for landmarks and table headers

## Testing
- `flake8 src/ tests/` *(fails: undefined names and line length violations in unrelated modules)*
- `pytest -q` *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0779552648329ac31b6e8c8694c0a